### PR TITLE
add exception messages in ChassImporter & update Session model

### DIFF
--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -15,9 +15,9 @@ class ImportController < ApplicationController
     import = ChassImporter.new(params[:chass_json], params[:semester], params[:year])
     status = import.get_status
     if status[:success]
-      render json: {message: status[:message], imported: status[:imported]}
+      render json: {message: status[:message], errors: status[:errors]}
     else
-      render status: 404, json: {message: status[:message], imported: status[:imported]}
+      render status: 404, json: {message: status[:message], errors: status[:errors]}
     end
   end
 

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -12,12 +12,12 @@ class ImportController < ApplicationController
   end
 
   def chass
-    import = ChassImporter.new(params[:chass_json])
+    import = ChassImporter.new(params[:chass_json], params[:semester], params[:year])
     status = import.get_status
     if status[:success]
-      render json: {message: status[:message]}
+      render json: {message: status[:message], imported: status[:imported]}
     else
-      render status: 404, json: {message: status[:message]}
+      render status: 404, json: {message: status[:message], imported: status[:imported]}
     end
   end
 

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -23,6 +23,8 @@ class Offer < ApplicationRecord
     end
     data = {
       position: position[:position],
+      start_date: position[:start_date],
+      end_date: position[:end_date],
       applicant: applicant,
       session: session,
       instructors: [],

--- a/app/models/offer.rb
+++ b/app/models/offer.rb
@@ -1,8 +1,9 @@
 class Offer < ApplicationRecord
+  validates_uniqueness_of :position_id, scope: [:applicant_id]
+  belongs_to :applicant
+  belongs_to :position
   include Model
   include Mangler
-  validates_uniqueness_of :position_id, scope: [:applicant_id]
-  has_one :contract
 
   def get_deadline
     offer = self.json

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -2,7 +2,7 @@ class Position < ApplicationRecord
   has_many :assignments
   has_many :preferences
   has_and_belongs_to_many :instructors
-  belongs_to :session
+  belongs_to :session, optional: true
 
   validates_uniqueness_of :position, scope: :round_id
 end

--- a/app/models/position.rb
+++ b/app/models/position.rb
@@ -2,7 +2,7 @@ class Position < ApplicationRecord
   has_many :assignments
   has_many :preferences
   has_and_belongs_to_many :instructors
-  belongs_to :session, optional: true
+  belongs_to :session
 
   validates_uniqueness_of :position, scope: :round_id
 end

--- a/app/services/chass_importer.rb
+++ b/app/services/chass_importer.rb
@@ -11,13 +11,13 @@ class ChassImporter
       create_session(semester, year)
       insert_data
     else
-      @import_status = {success: false, imported: false, message: [@round_id[:message]]}
+      @import_status = {success: false, errors: true, message: [@round_id[:message]]}
     end
   end
 
   def get_status
     if @exceptions.length > 0
-      {success: true, imported: true, message: @exceptions}
+      {success: true, errors: true, message: @exceptions}
     else
       @import_status
     end
@@ -28,7 +28,7 @@ class ChassImporter
     insert_positions
     insert_applicant
     insert_application
-    @import_status = {success: true, imported: true, message: ["CHASS import completed."]}
+    @import_status = {success: true, errors: false, message: ["CHASS import completed."]}
   end
 
   def get_round_id

--- a/app/services/chass_importer.rb
+++ b/app/services/chass_importer.rb
@@ -217,46 +217,44 @@ class ChassImporter
       course_id = posting_id.split("-")[0].strip
       round_id = course_entry["round_id"]
       session_id = get_session_id(course_entry["dates"])
-      if session_id
-        exists = "Position #{posting_id} already exists"
-        ident = {position: posting_id, round_id: round_id}
-        data = {
-          position: posting_id,
-          round_id: round_id,
-          open: true,
-          campus_code: course_id[course_id[/[A-Za-z0-9]{3}\d{3,4}/].size+1].to_i,
-          course_name: course_entry["course_name"].strip,
-          current_enrollment: course_entry["enrollment"],
-          duties: course_entry["duties"],
-          qualifications: course_entry["qualifications"],
-          hours: course_entry["n_hours"],
-          estimated_count: course_entry["n_positions"],
-          estimated_total_hours: course_entry["total_hours"],
-          session_id: session_id,
-        }
-        position = insertion_helper(Position, data, ident, exists)
+      exists = "Position #{posting_id} already exists"
+      ident = {position: posting_id, round_id: round_id}
+      data = {
+        position: posting_id,
+        round_id: round_id,
+        open: true,
+        campus_code: course_id[course_id[/[A-Za-z0-9]{3}\d{3,4}/].size+1].to_i,
+        course_name: course_entry["course_name"].strip,
+        current_enrollment: course_entry["enrollment"],
+        duties: course_entry["duties"],
+        qualifications: course_entry["qualifications"],
+        hours: course_entry["n_hours"],
+        estimated_count: course_entry["n_positions"],
+        estimated_total_hours: course_entry["total_hours"],
+        session_id: session_id,
+      }
+      position = insertion_helper(Position, data, ident, exists)
 
-        teaching_instructors = []
-        course_entry["instructor"].each do |instructor|
-          name = instructor["first_name"].strip+" "+instructor["last_name"].strip
-          ident = {name: name}
-          exists = "Instructor #{name} alread exists"
-          data = {
-              name: name,
-              email: instructor["email"],
-              utorid: instructor["utorid"],
-          }
-          instructor = insertion_helper(Instructor, data, ident, exists)
-          teaching_instructors.push(instructor[:id])
-          unless position.instructors.where(id: instructor[:id]).exists?
-            position.instructors << [instructor]
-          end
+      teaching_instructors = []
+      course_entry["instructor"].each do |instructor|
+        name = instructor["first_name"].strip+" "+instructor["last_name"].strip
+        ident = {name: name}
+        exists = "Instructor #{name} alread exists"
+        data = {
+            name: name,
+            email: instructor["email"],
+            utorid: instructor["utorid"],
+        }
+        instructor = insertion_helper(Instructor, data, ident, exists)
+        teaching_instructors.push(instructor[:id])
+        unless position.instructors.where(id: instructor[:id]).exists?
+          position.instructors << [instructor]
         end
-        position.instructors.each do |instructor|
-          if !teaching_instructors.include?(instructor[:id])
-            position.instructors.delete(instructor)
-            Rails.logger.debug "all instructors for Position #{position[:id]}: #{JSON.pretty_generate(position.instructors.as_json)}"
-          end
+      end
+      position.instructors.each do |instructor|
+        if !teaching_instructors.include?(instructor[:id])
+          position.instructors.delete(instructor)
+          Rails.logger.debug "all instructors for Position #{position[:id]}: #{JSON.pretty_generate(position.instructors.as_json)}"
         end
       end
     end

--- a/app/services/chass_importer.rb
+++ b/app/services/chass_importer.rb
@@ -280,8 +280,6 @@ class ChassImporter
     semester = get_semester(start_date)
     if semester
       data ={
-        start_date: start_date,
-        end_date: end_date,
         year: start_date.strftime("%Y"),
         semester: semester,
       }

--- a/app/services/chass_importer.rb
+++ b/app/services/chass_importer.rb
@@ -269,12 +269,8 @@ class ChassImporter
         dates = dates[0].split(" - ")
         if dates.size == 2
           return get_session(dates)
-        else
-          return nil
         end
       end
-    else
-      return nil
     end
   end
 
@@ -293,8 +289,6 @@ class ChassImporter
       ident = {year: data[:year], semester: data[:semester]}
       session = insertion_helper(Session, data, ident, exists)
       return session.id
-    else
-      return nil
     end
   end
 

--- a/app/services/chass_importer.rb
+++ b/app/services/chass_importer.rb
@@ -65,6 +65,7 @@ class ChassImporter
   end
 
   def create_session(semester, year)
+    semester = semester.slice(0,1).upcase + semester.slice(1..-1).downcase
     data ={
         year: year,
         semester: semester,

--- a/app/services/chass_importer.rb
+++ b/app/services/chass_importer.rb
@@ -17,7 +17,7 @@ class ChassImporter
 
   def get_status
     if @exceptions.length > 0
-      {success: false, imported: true, message: @exceptions}
+      {success: true, imported: true, message: @exceptions}
     else
       @import_status
     end

--- a/app/services/templates/letter.html.erb
+++ b/app/services/templates/letter.html.erb
@@ -1,6 +1,6 @@
 Dear <%= @offer[:applicant][:first_name] %> <%= @offer[:applicant][:last_name] %>,
 
-<%= @tab %>I am pleased to offer you an appointment as a Teaching Assistant in the Department of Computer Science. The starting date of your appointment will be <b><%= format_time(@offer[:session][:start_date],1) %></b> and this appointment will end on <b><%= format_time(@offer[:session][:end_date],1) %></b> with no further notice to you.
+<%= @tab %>I am pleased to offer you an appointment as a Teaching Assistant in the Department of Computer Science. The starting date of your appointment will be <b><%= format_time(@offer[:start_date],1) %></b> and this appointment will end on <b><%= format_time(@offer[:end_date],1) %></b> with no further notice to you.
 
 Your appointment will be for <b><%= '%.2f' % @offer[:hours] %></b> hours for <b><%= @offer[:position] %></b>, and your supervisor will be Professor <%= list_instructors(@offer[:instructors]) %>.  You will be paid $<%= '%.2f' % @offer[:session][:pay] %>/hour.  You will be paid in instalments, once per month for the period of your appointment. Your salary will be paid by direct deposit.  Your total salary is $<%= '%.2f' % (@offer[:session][:pay]* @offer[:hours]) %> plus 4% vacation pay  $<%= '%.2f' % (@offer[:session][:pay]* @offer[:hours]*4*0.04) %> for a total of  $<%= '%.2f' % ((@offer[:session][:pay]* @offer[:hours])+(@offer[:session][:pay]* @offer[:hours]*4*0.04)) %>.
 

--- a/app/services/templates/office_form.html.erb
+++ b/app/services/templates/office_form.html.erb
@@ -12,7 +12,7 @@
 
 <tablerow>Personnel Number: :Name:<%= @offer[:applicant][:first_name] %> <%= @offer[:applicant][:last_name] %>
 
-<tablerow>Start Date: <%= format_time(@offer[:session][:start_date],2) %>:End Date: <%= format_time(@offer[:session][:end_date],2) %>
+<tablerow>Start Date: <%= format_time(@offer[:start_date],2) %>:End Date: <%= format_time(@offer[:end_date],2) %>
 
 <tablerow>Wage Type: 01 15
 
@@ -24,7 +24,7 @@
 
 <b>New Employee:</b>
 
-<tablerow>Personnel Number: :Start Date: <%= format_time(@offer[:session][:start_date],2) %>
+<tablerow>Personnel Number: :Start Date: <%= format_time(@offer[:start_date],2) %>
 
 <tablerow>Form-of-add: :Last Name: <%= @offer[:applicant][:last_name] %>:First Name: <%= @offer[:applicant][:first_name] %>
 

--- a/db/migrate/20170829204432_add_dates_to_position.rb
+++ b/db/migrate/20170829204432_add_dates_to_position.rb
@@ -1,7 +1,7 @@
 class AddDatesToPosition < ActiveRecord::Migration[5.1]
   def change
-    add_column :positions, :start_date, :datetime
-    add_column :positions, :end_date, :datetime
+    add_column :positions, :start_date, :datetime, null: true
+    add_column :positions, :end_date, :datetime, null: true
 
     reversible do |dir|
       dir.up do
@@ -16,7 +16,7 @@ class AddDatesToPosition < ActiveRecord::Migration[5.1]
       dir.down do
         execute <<-SQL
           UPDATE positions
-          SET start_date=sessions.start_date, end_date=sessions.end_date 
+          SET start_date=sessions.start_date, end_date=sessions.end_date
           FROM sessions
           WHERE positions.session_id=sessions.id;
         SQL

--- a/db/migrate/20170829204432_add_dates_to_position.rb
+++ b/db/migrate/20170829204432_add_dates_to_position.rb
@@ -1,0 +1,30 @@
+class AddDatesToPosition < ActiveRecord::Migration[5.1]
+  def change
+    add_column :positions, :start_date, :datetime
+    add_column :positions, :end_date, :datetime
+
+    reversible do |dir|
+      dir.up do
+        execute <<-SQL
+          UPDATE positions
+          SET start_date=sessions.start_date, end_date=sessions.end_date
+          FROM sessions
+          WHERE positions.session_id=sessions.id;
+        SQL
+      end
+
+      dir.down do
+        execute <<-SQL
+          UPDATE positions
+          SET start_date=sessions.start_date, end_date=sessions.end_date 
+          FROM sessions
+          WHERE positions.session_id=sessions.id;
+        SQL
+      end
+    end
+
+
+    remove_column :sessions, :start_date, :datetime
+    remove_column :sessions, :end_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -94,7 +94,6 @@ ActiveRecord::Schema.define(version: 20170828170241) do
     t.string "signature"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "accept_date"
     t.index ["applicant_id"], name: "index_offers_on_applicant_id"
     t.index ["position_id"], name: "index_offers_on_position_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170828170241) do
+ActiveRecord::Schema.define(version: 20170829204432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,8 @@ ActiveRecord::Schema.define(version: 20170828170241) do
     t.bigint "session_id"
     t.integer "cap_enrollment"
     t.integer "num_waitlisted"
+    t.datetime "start_date"
+    t.datetime "end_date"
     t.index ["campus_code"], name: "index_positions_on_campus_code"
     t.index ["open"], name: "index_positions_on_open"
     t.index ["position", "round_id"], name: "index_positions_on_position_and_round_id", unique: true
@@ -133,8 +135,6 @@ ActiveRecord::Schema.define(version: 20170828170241) do
 
   create_table "sessions", force: :cascade do |t|
     t.integer "year"
-    t.datetime "start_date"
-    t.datetime "end_date"
     t.string "semester"
     t.float "pay", default: 0.0
     t.datetime "created_at", null: false

--- a/spec/controllers/assignments_controller_spec.rb
+++ b/spec/controllers/assignments_controller_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe AssignmentsController, type: :controller do
     Session.create!(
       semester: "Fall",
       year: 2017,
-      start_date: "2017-09-01 00:00:00 UTC",
-      end_date: "2017-12-31 00:00:00 UTC",
     )
   end
 
@@ -28,6 +26,8 @@ RSpec.describe AssignmentsController, type: :controller do
         session_id: session.id,
         cap_enrollment: nil,
         num_waitlisted: nil,
+        start_date: "2017-09-01 00:00:00 UTC",
+        end_date: "2017-12-31 00:00:00 UTC",
         )
 
       @applicant = Applicant.create!(
@@ -176,6 +176,8 @@ RSpec.describe AssignmentsController, type: :controller do
         session_id: session.id,
         cap_enrollment: nil,
         num_waitlisted: nil,
+        start_date: "2017-09-01 00:00:00 UTC",
+        end_date: "2017-12-31 00:00:00 UTC",
         )
 
       @position = Position.create!(
@@ -272,6 +274,8 @@ RSpec.describe AssignmentsController, type: :controller do
         session_id: session.id,
         cap_enrollment: nil,
         num_waitlisted: nil,
+        start_date: "2017-09-01 00:00:00 UTC",
+        end_date: "2017-12-31 00:00:00 UTC",
         )
 
       @applicant = Applicant.create!(
@@ -361,6 +365,8 @@ RSpec.describe AssignmentsController, type: :controller do
         session_id: session.id,
         cap_enrollment: nil,
         num_waitlisted: nil,
+        start_date: "2017-09-01 00:00:00 UTC",
+        end_date: "2017-12-31 00:00:00 UTC",
         )
 
       @applicant = Applicant.create!(

--- a/spec/controllers/export_controller_spec.rb
+++ b/spec/controllers/export_controller_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe ExportController, type: :controller do
     Session.create!(
       semester: "Fall",
       year: 2017,
-      start_date: "2017-09-01 00:00:00 UTC",
-      end_date: "2017-12-31 00:00:00 UTC",
     )
   end
 
@@ -26,6 +24,8 @@ RSpec.describe ExportController, type: :controller do
     session_id: session.id,
     cap_enrollment: nil,
     num_waitlisted: nil,
+    start_date: "2017-09-01 00:00:00 UTC",
+    end_date: "2017-12-31 00:00:00 UTC",
     )
   end
 

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe OffersController, type: :controller do
     Session.create!(
       semester: "Fall",
       year: 2017,
-      start_date: "2017-09-01 00:00:00 UTC",
-      end_date: "2017-12-31 00:00:00 UTC",
     )
   end
 
@@ -24,6 +22,8 @@ RSpec.describe OffersController, type: :controller do
       estimated_count: 17,
       estimated_total_hours: 918,
       session_id: session.id,
+      start_date: "2017-09-01 00:00:00 UTC",
+      end_date: "2017-12-31 00:00:00 UTC",
     )
   end
 

--- a/spec/controllers/positions_controller_spec.rb
+++ b/spec/controllers/positions_controller_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe PositionsController, type: :controller do
     Session.create!(
       semester: "Fall",
       year: 2017,
-      start_date: "2017-09-01 00:00:00 UTC",
-      end_date: "2017-12-31 00:00:00 UTC",
     )
   end
 
@@ -25,6 +23,8 @@ RSpec.describe PositionsController, type: :controller do
       estimated_count: 17,
       estimated_total_hours: 918,
       session_id: session.id,
+      start_date: "2017-09-01 00:00:00 UTC",
+      end_date: "2017-12-31 00:00:00 UTC",
     )
   end
 
@@ -82,6 +82,8 @@ RSpec.describe PositionsController, type: :controller do
           session_id: session.id,
           cap_enrollment: nil,
           num_waitlisted: nil,
+          start_date: "2017-09-01 00:00:00 UTC",
+          end_date: "2017-12-31 00:00:00 UTC",
         }
         expect(position.instructor_ids).to eq([])
         put :update, params: @params

--- a/spec/controllers/session_controller_spec.rb
+++ b/spec/controllers/session_controller_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe SessionsController, type: :controller do
     Session.create!(
       semester: "Fall",
       year: 2017,
-      start_date: "2017-09-01 00:00:00 UTC",
-      end_date: "2017-12-31 00:00:00 UTC",
     )
   end
 

--- a/spec/services/chass_exporter_spec.rb
+++ b/spec/services/chass_exporter_spec.rb
@@ -6,8 +6,6 @@ describe ChassExporter do
     Session.create!(
       semester: "Fall",
       year: 2017,
-      start_date: "2017-09-01 00:00:00 UTC",
-      end_date: "2017-12-31 00:00:00 UTC",
     )
   end
   let(:position) do
@@ -26,6 +24,8 @@ describe ChassExporter do
     session_id: session.id,
     cap_enrollment: nil,
     num_waitlisted: nil,
+    start_date: "2017-09-01 00:00:00 UTC",
+    end_date: "2017-12-31 00:00:00 UTC",
     )
   end
 

--- a/spec/services/chass_importer_spec.rb
+++ b/spec/services/chass_importer_spec.rb
@@ -251,7 +251,7 @@ end
     context "file with no round_id" do
       let(:mock_json) { File.read("./spec/support/chass_data/no_round.json") }
       it "returns error json" do
-        error = {success: false, imported: false, message: ["Import Failure: no round_id found in the file"]}
+        error = {success: false, errors: true, message: ["Import Failure: no round_id found in the file"]}
         expect(subject.get_status).to eq(error)
       end
     end
@@ -259,7 +259,7 @@ end
     context "file with more than one round_id" do
       let(:mock_json) { File.read("./spec/support/chass_data/too_many_rounds.json") }
       it "returns error json" do
-        error = {success: false, imported: false, message: ["Import Failure: too many round_ids found in the file"]}
+        error = {success: false, errors: true, message: ["Import Failure: too many round_ids found in the file"]}
         expect(subject.get_status).to eq(error)
       end
     end
@@ -267,7 +267,7 @@ end
     context "expected file" do
       let(:mock_json) { File.read("./spec/support/chass_data/applicant.json") }
       it "returns success json with imported true" do
-        success = {success: true, imported: true, message: ["CHASS import completed."]}
+        success = {success: true, errors: false, message: ["CHASS import completed."]}
         expect(subject.get_status).to eq(success)
       end
     end
@@ -275,7 +275,7 @@ end
     context "expected file with bad dates" do
       let(:mock_json) { File.read("./spec/support/chass_data/applicant_bad_dates.json") }
       it "returns errors json with imported true" do
-        success = {success: true, imported: true, message: ["Error: The dates for Position CSC100H1S is malformed."]}
+        success = {success: true, errors: true, message: ["Error: The dates for Position CSC100H1S is malformed."]}
         expect(subject.get_status).to eq(success)
       end
     end

--- a/spec/services/chass_importer_spec.rb
+++ b/spec/services/chass_importer_spec.rb
@@ -4,7 +4,7 @@ describe ChassImporter do
   let(:test_filename) { 'test/stub' }
   subject {
     data = JSON.parse(File.read("#{Rails.root}/db/#{test_filename}.json"))
-    ChassImporter.new(data)
+    ChassImporter.new(data, "Fall", 2017)
   }
 
   before :each do

--- a/spec/services/chass_importer_spec.rb
+++ b/spec/services/chass_importer_spec.rb
@@ -19,20 +19,6 @@ describe ChassImporter do
   end
 
   context "when parsing courses" do
-    context "with no dates" do
-      let(:mock_json) { File.read("./spec/support/chass_data/no_dates.json") }
-      before(:each) do
-        # Sanity checking -- shouldn't ever fail
-        expect(Position.all.count).to eq(0)
-      end
-
-      before(:each) { subject } # Evaluate subject
-
-      it "does not insert the position" do
-        expect(Position.where(position: "CSC100H1S").count).to eq(0)
-      end
-    end
-
     context "with a plain course" do
       let(:mock_json) { File.read("./spec/support/chass_data/plain_course.json") }
 

--- a/spec/services/chass_importer_spec.rb
+++ b/spec/services/chass_importer_spec.rb
@@ -4,7 +4,7 @@ describe ChassImporter do
   let(:test_filename) { 'test/stub' }
   subject {
     data = JSON.parse(File.read("#{Rails.root}/db/#{test_filename}.json"))
-    ChassImporter.new(data, "Fall", 2017)
+    ChassImporter.new(data, "fall", 2017)
   }
 
   before :each do

--- a/spec/services/chass_importer_spec.rb
+++ b/spec/services/chass_importer_spec.rb
@@ -251,7 +251,7 @@ end
     context "file with no round_id" do
       let(:mock_json) { File.read("./spec/support/chass_data/no_round.json") }
       it "returns error json" do
-        error = {success: false, message: "Import Failure: no round_id found in the file"}
+        error = {success: false, imported: false, message: ["Import Failure: no round_id found in the file"]}
         expect(subject.get_status).to eq(error)
       end
     end
@@ -259,15 +259,23 @@ end
     context "file with more than one round_id" do
       let(:mock_json) { File.read("./spec/support/chass_data/too_many_rounds.json") }
       it "returns error json" do
-        error = {success: false, message: "Import Failure: too many round_ids found in the file"}
+        error = {success: false, imported: false, message: ["Import Failure: too many round_ids found in the file"]}
         expect(subject.get_status).to eq(error)
       end
     end
 
     context "expected file" do
       let(:mock_json) { File.read("./spec/support/chass_data/applicant.json") }
-      it "returns sucess json" do
-        success = {success: true, message: "CHASS import completed."}
+      it "returns success json with imported true" do
+        success = {success: true, imported: true, message: ["CHASS import completed."]}
+        expect(subject.get_status).to eq(success)
+      end
+    end
+
+    context "expected file with bad dates" do
+      let(:mock_json) { File.read("./spec/support/chass_data/applicant_bad_dates.json") }
+      it "returns errors json with imported true" do
+        success = {success: true, imported: true, message: ["Error: The dates for Position CSC100H1S is malformed."]}
         expect(subject.get_status).to eq(success)
       end
     end

--- a/spec/services/csv_generator_spec.rb
+++ b/spec/services/csv_generator_spec.rb
@@ -7,8 +7,6 @@ describe CSVGenerator do
     Session.create!(
       semester: "Fall",
       year: 2017,
-      start_date: "2017-09-01 00:00:00 UTC",
-      end_date: "2017-12-31 00:00:00 UTC",
     )
   end
   let(:position) do
@@ -27,6 +25,8 @@ describe CSVGenerator do
     session_id: session.id,
     cap_enrollment: nil,
     num_waitlisted: nil,
+    start_date: "2017-09-01 00:00:00 UTC",
+    end_date: "2017-12-31 00:00:00 UTC",
     )
   end
 

--- a/spec/services/enrollment_updater_spec.rb
+++ b/spec/services/enrollment_updater_spec.rb
@@ -11,8 +11,6 @@ describe EnrollmentUpdater do
     Session.create!(
       semester: "Fall",
       year: 2017,
-      start_date: "2017-09-01 00:00:00 UTC",
-      end_date: "2017-12-31 00:00:00 UTC",
     )
   end
   let(:position) do
@@ -31,6 +29,8 @@ describe EnrollmentUpdater do
     session_id: session.id,
     cap_enrollment: nil,
     num_waitlisted: nil,
+    start_date: "2017-09-01 00:00:00 UTC",
+    end_date: "2017-12-31 00:00:00 UTC",
     )
   end
   failure = {updated: false, message: "Error: This file is not formatted correctly."}

--- a/spec/support/chass_data/applicant_bad_dates.json
+++ b/spec/support/chass_data/applicant_bad_dates.json
@@ -1,0 +1,51 @@
+{
+    "courses": [
+        {
+            "course_id": "CSC100H1S",
+            "course_name": "First Year Office Hour TA",
+            "round_id": "110",
+            "enrollment": null,
+            "n_positions": "5",
+            "n_hours": "54",
+            "dates": null,
+            "tutorials": null,
+            "qualifications": "Must be enrolled in or have completed a computer science degree, or equivalent. Must meet the qualifications to TA *ALL* of CSC 108, 148, and 165 (see CSC108H1-B, CSC148H1, CSC165H1 qualifications). Enthusiasm and patience for face-to-face teaching of beginners is required. Experience with CSC 104 or Racket preferred.",
+            "duties": "Hold office hours on a weekly basis to assist students taking 100-level CSC courses.",
+            "total_hours": "270",
+            "start_posting": null,
+            "end_posting": null,
+            "status": "1",
+            "dates": "poops",
+            "end_nominations": null,
+            "last_updated": "2017-05-31 10:55:56",
+            "instructor": []
+        }
+    ],
+    "applicants": [
+        {
+            "app_id": "478",
+            "utorid": "applicant478",
+            "first_name": "Luklorizur",
+            "last_name": "Mrokarczur",
+            "email": "luklorizur.mrokarczur@mail.utoronto.ca",
+            "phone": "6476879273",
+            "student_no": "1425362850",
+            "address": "478 Karczur St.",
+            "ta_training": "N",
+            "access_acad_history": "N",
+            "dept": "Physics",
+            "program_id": "8UG",
+            "yip": "10",
+            "course_preferences": "CSC100H1S",
+            "ta_experience": "CSC148H5S (9), CSC258H5S (5), CSC300H1S (3), CSC209H1S (2), CSC321H1S (1)",
+            "academic_qualifications": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+            "technical_skills": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+            "full_time": "Y",
+            "availability": "Available",
+            "other_info": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+            "special_needs": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Ut eget dignissim sem. Curabitur at semper eros. Aenean nec sem lobortis, scelerisque mi at, aliquam diam. Mauris malesuada elit nibh, sed hendrerit nulla mattis sed. Mauris laoreet imperdiet dictum. Pellentesque risus nulla, varius ut massa ut, venenatis fringilla sapien. Cras eget euismod augue, eget dignissim erat. Cras nec nibh ullamcorper ante rutrum dapibus sed nec tellus. In hac habitasse platea dictumst. Suspendisse semper tellus ac sem tincidunt auctor.",
+            "last_updated": "2017-06-16 10:18:37",
+            "courses": ["CSC100H1S"]
+        }
+    ]
+}


### PR DESCRIPTION
Port of @michellemtchai's TAPP PR #211: https://github.com/uoft-tapp/tapp/pull/211

Changes:
- create migration to move `start_date` and `end_date` from `Session` to `Position`
- make `semester` and `year` a required parameter for `POST /import/chass`
  - Note: `semester` is a string, and `year` is an int
- fix rspecs
- route returns response in the form of `{message: array of strings, errors: boolean}`

Response:
- case 1: expected data
  - status 200, errors: false
- case 2: malformed dates
  - status 200, errors: true
- case 3: round_id issues
  - status 404, errors: true