### PR TITLE
additional front-end features

### DIFF
--- a/app/assets/stylesheets/cp.scss
+++ b/app/assets/stylesheets/cp.scss
@@ -4,7 +4,8 @@
     --navbar-height: 71px; /* includes margins */
     --table-menu-height: calc(34px + 1vh);
     --main-div-height: calc(100vh - var(--navbar-height) - var(--footer-height));
-    --sessions-height: calc(100px + 1.5vh);
+    --min-row-height: 52px; /* assumes that header is two rows high */
+    --sessions-height: calc(87px + 1.5vh);
 }
 
 html {
@@ -100,9 +101,16 @@ footer div p {
     margin-left: 3vw;
 }
 
-/* for Table in admin view */
 #offers-grid table {
     margin: 0;
+}
+
+/* for Table in admin view */
+#offers-grid .sessions ~ .table-container .table-body {
+    /* note that this assumes that the header is at most one row high */
+    max-height: calc(
+        var(--main-div-height) - var(--table-menu-height) - var(--min-row-height) - var(--sessions-height)
+    );
 }
 
 #offers-grid .table-body {
@@ -113,11 +121,8 @@ footer div p {
     overflow: auto;
 }
 
-#offers-grid .admin-table .table-body {
-    /* note that this assumes that the header is at most one row high */
-    max-height: calc(
-        var(--main-div-height) - var(--table-menu-height) - var(--min-row-height) - var(--sessions-height)
-    );
+#offers-grid .table-container th {
+    text-overflow: ellipsis;
 }
 
 #offers-grid .table-container td,
@@ -130,11 +135,11 @@ footer div p {
     border: 1px solid #ddd;
 }
 
-#offers-grid .nav-tabs {
+#offers-grid .sessions .nav-tabs {
     background-color: #f5f5f5;
 }
 
-#offers-grid .tab-content {
+#offers-grid .sessions .tab-content {
     height: calc(35px + 5px + 5px);
     padding: 5px 15px;
 }

--- a/app/assets/stylesheets/cp.scss
+++ b/app/assets/stylesheets/cp.scss
@@ -144,7 +144,7 @@ footer div p {
     padding: 5px 15px;
 }
 
-#offers-grid .sessions .input-group {
+#offers-grid .sessions input {
     width: 150px;
 }
 

--- a/app/assets/stylesheets/cp.scss
+++ b/app/assets/stylesheets/cp.scss
@@ -137,6 +137,8 @@ footer div p {
 
 #offers-grid .sessions .nav-tabs {
     background-color: #f5f5f5;
+    overflow-x: auto;
+    overflow-y: hidden;
 }
 
 #offers-grid .sessions .tab-content {

--- a/app/assets/stylesheets/cp.scss
+++ b/app/assets/stylesheets/cp.scss
@@ -5,7 +5,7 @@
     --table-menu-height: calc(34px + 1vh);
     --main-div-height: calc(100vh - var(--navbar-height) - var(--footer-height));
     --min-row-height: 52px; /* assumes that header is two rows high */
-    --sessions-height: calc(87px + 1.5vh);
+    --sessions-height: calc(55px + 1.5vh);
 }
 
 html {
@@ -132,22 +132,19 @@ footer div p {
 
 #offers-grid .sessions {
     margin: 0 0 1.5vh 0;
-    border: 1px solid #ddd;
 }
 
-#offers-grid .sessions .nav-tabs {
-    background-color: #f5f5f5;
-    overflow-x: auto;
-    overflow-y: hidden;
+#offers-grid .sessions .panel-body {
+    height: calc(35px + 10px + 10px);
+    padding: 10px 15px;
 }
 
-#offers-grid .sessions .tab-content {
-    height: calc(35px + 5px + 5px);
-    padding: 5px 15px;
+#offers-grid .sessions #pay {
+    margin-left: 1vw;
 }
 
-#offers-grid .sessions input {
-    width: 150px;
+#offers-grid .sessions #pay input {
+    width: 100px;
 }
 
 .highlightOnHover:hover {

--- a/app/javascript/cp/appState.js
+++ b/app/javascript/cp/appState.js
@@ -242,9 +242,30 @@ class AppState {
         return [this.get('offers.list'), this.get('sessions.list')].some(val => val == null);
     }
 
+    // email applicants
     email(offers) {
         let allOffers = this.getOffersList();
-        fetch.email(offers.map(offer => allOffers.getIn([offer, 'email'])));
+        let emails = offers.map(offer => allOffers.getIn([offer, 'email']));
+
+        var a = document.createElement('a');
+        a.href =
+            emails.length == 1
+                ? 'mailto:' + emails[0] // if there is only a single recipient, send normally
+                : 'mailto:?bcc=' + emails.join(';'); // if there are multiple recipients, bcc all
+        a.click();
+    }
+
+    // email mangled contract link to a single applicant
+    emailContract(offers) {
+        if (offers.length != 1) {
+            this.alert('<b>Error:</b> Can only email a contract link to a single applicant.');
+        }
+        let offer = this.getOffersList().get(offers[0]);
+
+        var a = document.createElement('a');
+        a.href =
+            'mailto:' + offer.get('email') + '?body=Link%20to%20contract:%20' + offer.get('link');
+        a.click();
     }
 
     // check if offers are being fetched

--- a/app/javascript/cp/appState.js
+++ b/app/javascript/cp/appState.js
@@ -259,8 +259,21 @@ class AppState {
     emailContract(offers) {
         if (offers.length != 1) {
             this.alert('<b>Error:</b> Can only email a contract link to a single applicant.');
+            return;
         }
+
         let offer = this.getOffersList().get(offers[0]);
+        if (!offer.get('link')) {
+            // offers does not have a contract link
+            this.alert(
+                '<b>Error:</b> Offer to ' +
+                    offer.get('lastName') +
+                    ', ' +
+                    offer.get('firstName') +
+                    ' does not have an associated contract'
+            );
+            return;
+        }
 
         var a = document.createElement('a');
         a.href =
@@ -317,6 +330,11 @@ class AppState {
     }
 
     nag(offers) {
+        if (offers.length == 0) {
+            this.alert('<b>Error</b>: No offer selected');
+            return;
+        }
+
         let pendingOffers = [],
             allOffers = this.getOffersList();
 
@@ -339,10 +357,20 @@ class AppState {
     }
 
     print(offers) {
+        if (offers.length == 0) {
+            this.alert('<b>Error</b>: No offer selected');
+            return;
+        }
+
         fetch.print(offers);
     }
 
     sendContracts(offers) {
+        if (offers.length == 0) {
+            this.alert('<b>Error</b>: No offer selected');
+            return;
+        }
+
         let status,
             unsentOffers = [],
             allOffers = this.getOffersList();
@@ -378,6 +406,11 @@ class AppState {
     }
 
     setDdahAccepted(offers) {
+        if (offers.length == 0) {
+            this.alert('<b>Error</b>: No offer selected');
+            return;
+        }
+
         let acceptedOffers = [],
             allOffers = this.getOffersList();
 
@@ -436,6 +469,11 @@ class AppState {
     }
 
     setHrProcessed(offers) {
+        if (offers.length == 0) {
+            this.alert('<b>Error</b>: No offer selected');
+            return;
+        }
+
         let acceptedOffers = [],
             allOffers = this.getOffersList();
 
@@ -496,6 +534,11 @@ class AppState {
     }
 
     withdrawOffers(offers) {
+        if (offers.length == 0) {
+            this.alert('<b>Error</b>: No offer selected');
+            return;
+        }
+
         let status,
             pendingOffers = [],
             allOffers = this.getOffersList();

--- a/app/javascript/cp/appState.js
+++ b/app/javascript/cp/appState.js
@@ -470,6 +470,10 @@ class AppState {
         fetch.showContractHr(offer);
     }
 
+    updateSessionPay(session, pay) {
+        fetch.updateSessionPay(session, pay);
+    }
+
     withdrawOffers(offers) {
         let status,
             pendingOffers = [],

--- a/app/javascript/cp/appState.js
+++ b/app/javascript/cp/appState.js
@@ -17,7 +17,7 @@ const initialState = {
     selectedSortFields: [],
     selectedFilters: {},
 
-    selectedSession: null,
+    selectedSession: '',
 
     /** DB data **/
     offers: { fetching: 0, list: null },

--- a/app/javascript/cp/appState.js
+++ b/app/javascript/cp/appState.js
@@ -335,7 +335,7 @@ class AppState {
             return;
         }
 
-        fetch.nag(offers);
+        fetch.nag(offers.map(offer => parseInt(offer)));
     }
 
     print(offers) {
@@ -344,7 +344,7 @@ class AppState {
             return;
         }
 
-        fetch.print(offers);
+        fetch.print(offers.map(offer => parseInt(offer)));
     }
 
     sendContracts(offers) {
@@ -353,7 +353,7 @@ class AppState {
             return;
         }
 
-        fetch.sendContracts(offers);
+        fetch.sendContracts(offers.map(offer => parseInt(offer)));
     }
 
     setDdahAccepted(offers) {
@@ -362,7 +362,7 @@ class AppState {
             return;
         }
 
-        fetch.setDdahAccepted(offers);
+        fetch.setDdahAccepted(offers.map(offer => parseInt(offer)));
     }
 
     setFetchingOffersList(fetching, success) {
@@ -407,7 +407,7 @@ class AppState {
             return;
         }
 
-        fetch.setHrProcessed(offers);
+        fetch.setHrProcessed(offers.map(offer => parseInt(offer)));
     }
 
     setImporting(importing, success) {

--- a/app/javascript/cp/appState.js
+++ b/app/javascript/cp/appState.js
@@ -433,6 +433,18 @@ class AppState {
     }
 
     setSessionsList(list) {
+        let semesterOrder = ['Winter', 'Spring', 'Fall', 'Year'];
+        // sort sesions in order of most recent to least recent
+        list.sort((sessionA, sessionB) => {
+            if (sessionA.get('year') > sessionB.get('year')) {
+                return -1;
+            }
+            if (sessionA.get('year') < sessionB.get('year')) {
+                return 1;
+            }
+            return semesterOrder.indexOf(sessionA.get('semester')) - semesterOrder.indexOf(sessionB.get('semester'));
+        });
+        
         this.set('sessions.list', list);
     }
 

--- a/app/javascript/cp/appState.js
+++ b/app/javascript/cp/appState.js
@@ -17,6 +17,8 @@ const initialState = {
     selectedSortFields: [],
     selectedFilters: {},
 
+    selectedSession: null,
+
     /** DB data **/
     offers: { fetching: 0, list: null },
     sessions: { fetching: 0, list: null },
@@ -143,6 +145,10 @@ class AppState {
         return this.get('selectedFilters');
     }
 
+    getSelectedSession() {
+        return this.get('selectedSession');
+    }
+
     getSorts() {
         return this.get('selectedSortFields');
     }
@@ -177,12 +183,16 @@ class AppState {
         this.set('selectedSortFields', sorts.delete(i));
     }
 
+    selectSession(session) {
+        this.set('selectedSession', session);
+    }
+
     setCurrentUserName(user) {
-        return this.set('user', user);
+        this.set('user', user);
     }
 
     setCurrentUserRole(role) {
-        return this.set('role', role);
+        this.set('role', role);
     }
 
     // toggle a filter on the offers table

--- a/app/javascript/cp/appState.js
+++ b/app/javascript/cp/appState.js
@@ -335,25 +335,7 @@ class AppState {
             return;
         }
 
-        let pendingOffers = [],
-            allOffers = this.getOffersList();
-
-        for (var offer of offers) {
-            if (allOffers.getIn([offer, 'status']) == 'Pending') {
-                pendingOffers.push(parseInt(offer));
-            } else {
-                // offers that are not 'pending' cannot be nagged about
-                this.alert(
-                    '<b>Error:</b> Offer to ' +
-                        allOffers.getIn([offer, 'lastName']) +
-                        ', ' +
-                        allOffers.getIn([offer, 'firstName']) +
-                        ' is not pending'
-                );
-            }
-        }
-
-        fetch.nag(pendingOffers);
+        fetch.nag(offers);
     }
 
     print(offers) {
@@ -371,38 +353,7 @@ class AppState {
             return;
         }
 
-        let status,
-            unsentOffers = [],
-            allOffers = this.getOffersList();
-
-        for (var offer of offers) {
-            status = allOffers.getIn([offer, 'status']);
-
-            switch (status) {
-                // can only send contracts that are unsent
-                case 'Unsent':
-                    unsentOffers.push(parseInt(offer));
-                    break;
-                case 'Withdrawn':
-                    this.alert(
-                        '<b>Error:</b> Cannot send contract to ' +
-                            allOffers.getIn([offer, 'lastName']) +
-                            ', ' +
-                            allOffers.getIn([offer, 'firstName']) +
-                            '. Offer was withdrawn.'
-                    );
-                    break;
-                default:
-                    this.alert(
-                        '<b>Error:</b> Contract has already been sent to ' +
-                            allOffers.getIn([offer, 'lastName']) +
-                            ', ' +
-                            allOffers.getIn([offer, 'firstName'])
-                    );
-            }
-        }
-
-        fetch.sendContracts(unsentOffers);
+        fetch.sendContracts(offers);
     }
 
     setDdahAccepted(offers) {
@@ -411,25 +362,7 @@ class AppState {
             return;
         }
 
-        let acceptedOffers = [],
-            allOffers = this.getOffersList();
-
-        for (var offer of offers) {
-            // can only accept DDAH form for accepted offers
-            if (allOffers.getIn([offer, 'status']) == 'Accepted') {
-                acceptedOffers.push(parseInt(offer));
-            } else {
-                this.alert(
-                    '<b>Error:</b> Cannot accept DDAH form for ' +
-                        allOffers.getIn([offer, 'lastName']) +
-                        ', ' +
-                        allOffers.getIn([offer, 'firstName']) +
-                        '. Offer is not accepted.'
-                );
-            }
-        }
-
-        fetch.setDdahAccepted(acceptedOffers);
+        fetch.setDdahAccepted(offers);
     }
 
     setFetchingOffersList(fetching, success) {
@@ -474,25 +407,7 @@ class AppState {
             return;
         }
 
-        let acceptedOffers = [],
-            allOffers = this.getOffersList();
-
-        for (var offer of offers) {
-            // can only process contract for accepted offers
-            if (allOffers.getIn([offer, 'status']) == 'Accepted') {
-                acceptedOffers.push(parseInt(offer));
-            } else {
-                this.alert(
-                    '<b>Error:</b> Cannot process contract for ' +
-                        allOffers.getIn([offer, 'lastName']) +
-                        ', ' +
-                        allOffers.getIn([offer, 'firstName']) +
-                        '. Offer is not accepted.'
-                );
-            }
-        }
-
-        fetch.setHrProcessed(acceptedOffers);
+        fetch.setHrProcessed(offers);
     }
 
     setImporting(importing, success) {
@@ -539,26 +454,7 @@ class AppState {
             return;
         }
 
-        let status,
-            pendingOffers = [],
-            allOffers = this.getOffersList();
-
-        for (var offer of offers) {
-            // cannot withdraw unsent offers
-            if (allOffers.getIn([offer, 'status']) == 'Unsent') {
-                this.alert(
-                    '<b>Error:</b> Offer to ' +
-                        allOffers.getIn([offer, 'lastName']) +
-                        ', ' +
-                        allOffers.getIn([offer, 'firstName']) +
-                        ' has not been sent'
-                );
-            } else {
-                pendingOffers.push(parseInt(offer));
-            }
-        }
-
-        fetch.withdrawOffers(pendingOffers);
+        fetch.withdrawOffers(offers);
     }
 }
 

--- a/app/javascript/cp/components/controlPanel.js
+++ b/app/javascript/cp/components/controlPanel.js
@@ -58,26 +58,31 @@ class ControlPanel extends React.Component {
                         className="offer-checkbox"
                         id={p.offerId}
                         onClick={event => {
-			    // range selection using shift key
-			    if (this.lastClicked && event.shiftKey) {
-				let first = false, last = false;
+                            // range selection using shift key (range is from current box (offerId) to last-clicked box
+                            if (this.lastClicked && event.shiftKey) {
+                                let first = false,
+                                    last = false;
 
-				Array.prototype.forEach.call(getCheckboxElements(), box => {
-				    if (!first && (box.id == p.offerId || box.id == this.lastClicked)) {
-					first = true;
-					box.checked = true;
-				    }
+                                Array.prototype.forEach.call(getCheckboxElements(), box => {
+                                    if (
+                                        !first &&
+                                        (box.id == p.offerId || box.id == this.lastClicked)
+                                    ) {
+                                        // starting box
+                                        first = true;
+                                        box.checked = true;
+                                    } else if (first && !last) {
+                                        // box is in range
+                                        if (box.id == p.offerId || box.id == this.lastClicked) {
+                                            // ending box
+                                            last = true;
+                                        }
+                                        box.checked = true;
+                                    }
+                                });
+                            }
 
-				    if (first && !last) {
-					if (box.id == p.offerId || box.id == this.lastClicked) {
-					    last = true;
-					}
-					box.checked = true;
-				    }
-				});
-			    }
-
-			    this.lastClicked = p.offerId;
+                            this.lastClicked = p.offerId;
                         }}
                     />,
 
@@ -123,7 +128,7 @@ class ControlPanel extends React.Component {
                     .getPositions()
                     .map(position => p => p.get('position') == position),
 
-                style: { width: 0.10 },
+                style: { width: 0.1 },
             },
             {
                 header: 'Hours',
@@ -172,7 +177,7 @@ class ControlPanel extends React.Component {
                         : '',
                 sortData: p => p.get('sentAt'),
 
-                style: { width: 0.10 },
+                style: { width: 0.1 },
             },
             {
                 header: 'Nag Count',
@@ -223,7 +228,7 @@ class ControlPanel extends React.Component {
         return (
             <Grid fluid id="offers-grid">
                 {role == 'admin' && <SessionsForm {...this.props} />}
-            
+
                 <ButtonToolbar id="dropdown-menu">
                     {role == 'admin' && <ImportMenu {...this.props} />}
                     {role == 'admin' && <OffersMenu {...this.props} />}
@@ -249,13 +254,14 @@ class ControlPanel extends React.Component {
                 <Table
                     config={this.config}
                     getOffers={() => {
-			let session = this.props.appState.getSelectedSession();
-			if (session != '') {
-			    return this.props.appState.getOffersList()
-				.filter(offer => offer.get('session') == session);
-			}
-			return this.props.appState.getOffersList();
-	            }}
+                        let session = this.props.appState.getSelectedSession();
+                        if (session != '') {
+                            return this.props.appState
+                                .getOffersList()
+                                .filter(offer => offer.get('session') == session);
+                        }
+                        return this.props.appState.getOffersList();
+                    }}
                     getSelectedSortFields={() => this.props.appState.getSorts()}
                     getSelectedFilters={() => this.props.appState.getFilters()}
                 />

--- a/app/javascript/cp/components/controlPanel.js
+++ b/app/javascript/cp/components/controlPanel.js
@@ -88,28 +88,28 @@ class ControlPanel extends React.Component {
                 data: p => p.offer.get('lastName'),
                 sortData: p => p.get('lastName'),
 
-                style: { width: 0.09 },
+                style: { width: 0.08 },
             },
             {
                 header: 'First Name',
                 data: p => p.offer.get('firstName'),
                 sortData: p => p.get('firstName'),
 
-                style: { width: 0.06 },
+                style: { width: 0.08 },
             },
             {
                 header: 'Email',
                 data: p => p.offer.get('email'),
                 sortData: p => p.get('email'),
 
-                style: { width: 0.13 },
+                style: { width: 0.16 },
             },
             {
                 header: 'Student Number',
                 data: p => p.offer.get('studentNumber'),
                 sortData: p => p.get('studentNumber'),
 
-                style: { width: 0.06 },
+                style: { width: 0.07 },
             },
             {
                 header: 'Position',
@@ -123,7 +123,7 @@ class ControlPanel extends React.Component {
                     .getPositions()
                     .map(position => p => p.get('position') == position),
 
-                style: { width: 0.08 },
+                style: { width: 0.10 },
             },
             {
                 header: 'Hours',
@@ -147,7 +147,7 @@ class ControlPanel extends React.Component {
                     'Withdrawn',
                 ].map(status => p => p.get('status') == status),
 
-                style: { width: 0.05 },
+                style: { width: 0.07 },
             },
             {
                 header: 'Contract Send Date',
@@ -172,14 +172,14 @@ class ControlPanel extends React.Component {
                         : '',
                 sortData: p => p.get('sentAt'),
 
-                style: { width: 0.08 },
+                style: { width: 0.10 },
             },
             {
                 header: 'Nag Count',
                 data: p => (p.offer.get('nagCount') ? p.offer.get('nagCount') : ''),
                 sortData: p => p.get('nagCount'),
 
-                style: { width: 0.04 },
+                style: { width: 0.05 },
             },
             {
                 header: 'HRIS Status',
@@ -192,7 +192,7 @@ class ControlPanel extends React.Component {
                     ['Processed', 'Printed'].map(status => p => p.get('hrStatus') == status)
                 ),
 
-                style: { width: 0.05 },
+                style: { width: 0.07 },
             },
             {
                 header: 'Printed Date',
@@ -217,8 +217,6 @@ class ControlPanel extends React.Component {
                         p.get('ddahStatus') == status
                     )
                 ),
-
-                style: { width: 0.06 },
             },
         ];
 
@@ -249,7 +247,6 @@ class ControlPanel extends React.Component {
                 </ButtonToolbar>
 
                 <Table
-                    className={role == 'admin' ? 'admin-table' : ''}
                     config={this.config}
                     getOffers={() => {
 			let session = this.props.appState.getSelectedSession();

--- a/app/javascript/cp/components/controlPanel.js
+++ b/app/javascript/cp/components/controlPanel.js
@@ -253,7 +253,7 @@ class ControlPanel extends React.Component {
                     config={this.config}
                     getOffers={() => {
 			let session = this.props.appState.getSelectedSession();
-			if (session != null) {
+			if (session != '') {
 			    return this.props.appState.getOffersList()
 				.filter(offer => offer.get('session') == session);
 			}

--- a/app/javascript/cp/components/controlPanel.js
+++ b/app/javascript/cp/components/controlPanel.js
@@ -288,7 +288,10 @@ const OffersMenu = props =>
 
 const CommMenu = props =>
     <DropdownButton bsStyle="primary" title="Communicate" id="comm-dropdown">
-        <MenuItem onClick={() => props.appState.email(getSelectedOffers())}>Email</MenuItem>
+        <MenuItem onClick={() => props.appState.email(getSelectedOffers())}>Email [blank]</MenuItem>
+        <MenuItem onClick={() => props.appState.emailContract(getSelectedOffers())}>
+            Email [contract]
+        </MenuItem>
         <MenuItem onClick={() => props.appState.nag(getSelectedOffers())}>Nag</MenuItem>
     </DropdownButton>;
 

--- a/app/javascript/cp/components/controlPanel.js
+++ b/app/javascript/cp/components/controlPanel.js
@@ -251,7 +251,14 @@ class ControlPanel extends React.Component {
                 <Table
                     className={role == 'admin' ? 'admin-table' : ''}
                     config={this.config}
-                    getOffers={() => this.props.appState.getOffersList()}
+                    getOffers={() => {
+			let session = this.props.appState.getSelectedSession();
+			if (session != null) {
+			    return this.props.appState.getOffersList()
+				.filter(offer => offer.get('session') == session);
+			}
+			return this.props.appState.getOffersList();
+	            }}
                     getSelectedSortFields={() => this.props.appState.getSorts()}
                     getSelectedFilters={() => this.props.appState.getFilters()}
                 />

--- a/app/javascript/cp/components/navbar.js
+++ b/app/javascript/cp/components/navbar.js
@@ -39,32 +39,6 @@ const Notifications = props => {
     );
 };
 
-const Session = props => {
-    if (props.appState.isSessionsListNull()) {
-        return null;
-    }
-
-    return (
-        <Navbar.Form>
-            <FormGroup>
-                <ControlLabel>Session</ControlLabel>&ensp;
-                <FormControl
-                    componentClass="select"
-                    onChange={event => props.appState.selectSession(event.target.value)}>
-                    <option value="" key="session-all">
-                        all
-                    </option>
-                    {props.appState.getSessionsList().map((session, sessionId) =>
-                        <option value={sessionId} key={'session-' + sessionId}>
-                            {session.get('semester')}&nbsp;{session.get('year')}
-                        </option>
-                    )}
-                </FormControl>
-            </FormGroup>
-        </Navbar.Form>
-    );
-};
-
 const Auth = props =>
     <NavDropdown
         title={props.appState.getCurrentUserRole() + ':' + props.appState.getCurrentUserName()}
@@ -93,11 +67,6 @@ const NavbarInst = props =>
         <Navbar.Header>
             <Navbar.Brand>TAPP:CP</Navbar.Brand>
         </Navbar.Header>
-
-        {props.appState.getCurrentUserRole() == 'admin' &&
-            <Nav pullLeft>
-                <Session {...props} />
-            </Nav>}
 
         <Nav pullRight>
             <Notifications {...props} />

--- a/app/javascript/cp/components/navbar.js
+++ b/app/javascript/cp/components/navbar.js
@@ -2,13 +2,13 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 
 import { Navbar,
-	 Nav,
-	 NavItem,
-	 NavDropdown,
-	 MenuItem,
-	 FormGroup,
-	 ControlLabel,
-	 FormControl }
+         Nav,
+         NavItem,
+         NavDropdown,
+         MenuItem,
+         FormGroup,
+         ControlLabel,
+         FormControl }
 from 'react-bootstrap';
 
 /*** Navbar components ***/
@@ -44,18 +44,20 @@ const Session = props => {
     }
     
     return (
-	<Navbar.Form>
-	    <FormGroup>
+        <Navbar.Form>
+            <FormGroup>
                 <ControlLabel>Session</ControlLabel>&ensp;
-                <FormControl componentClass="select">
-                <option value={null} key="session-all">-</option>
-	        {props.appState.getSessionsList().map((session, sessionId) =>
-			      <option value={sessionId} key={'session-' + sessionId}>
-                                  {session.get('semester')}&nbsp;{session.get('year')}
-			      </option>)}
-	        </FormControl>
-	    </FormGroup>
-	</Navbar.Form>
+                <FormControl
+                    componentClass="select"
+                    onChange={event => props.appState.selectSession(event.target.value)}>
+                    <option value={null} key="session-all">-</option>
+                    {props.appState.getSessionsList().map((session, sessionId) =>
+                        <option value={sessionId} key={'session-' + sessionId}>
+                            {session.get('semester')}&nbsp;{session.get('year')}
+                        </option>)}
+                </FormControl>
+            </FormGroup>
+        </Navbar.Form>
     );
 };
 

--- a/app/javascript/cp/components/navbar.js
+++ b/app/javascript/cp/components/navbar.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { Navbar, Nav, NavItem, NavDropdown, MenuItem } from 'react-bootstrap';
+import { Navbar,
+	 Nav,
+	 NavItem,
+	 NavDropdown,
+	 MenuItem,
+	 FormGroup,
+	 ControlLabel,
+	 FormControl }
+from 'react-bootstrap';
 
 /*** Navbar components ***/
 
@@ -27,6 +35,27 @@ const Notifications = props => {
                 <MenuItem key={'notification-' + i} dangerouslySetInnerHTML={{ __html: text }} />
             )}
         </NavDropdown>
+    );
+};
+
+const Session = props => {
+    if (props.isSessionsListNull()) {
+        return null;
+    }
+    
+    return (
+	<Navbar.Form>
+	    <FormGroup>
+                <ControlLabel>Session</ControlLabel>&ensp;
+                <FormControl componentClass="select">
+                <option value={null} key="session-all">-</option>
+	        {props.appState.getSessionsList().map((session, sessionId) =>
+			      <option value={sessionId} key={'session-' + sessionId}>
+                                  {session.get('semester')}&nbsp;{session.get('year')}
+			      </option>)}
+	        </FormControl>
+	    </FormGroup>
+	</Navbar.Form>
     );
 };
 
@@ -58,6 +87,11 @@ const NavbarInst = props =>
         <Navbar.Header>
             <Navbar.Brand>TAPP:CP</Navbar.Brand>
         </Navbar.Header>
+
+        {props.appState.getCurrentUserRole() == 'admin' &&
+            <Nav pullLeft>
+                <Sessions {...props} />
+            </Nav>}
 
         <Nav pullRight>
             <Notifications {...props} />

--- a/app/javascript/cp/components/navbar.js
+++ b/app/javascript/cp/components/navbar.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 
-import { Navbar,
-         Nav,
-         NavItem,
-         NavDropdown,
-         MenuItem,
-         FormGroup,
-         ControlLabel,
-         FormControl }
-from 'react-bootstrap';
+import {
+    Navbar,
+    Nav,
+    NavItem,
+    NavDropdown,
+    MenuItem,
+    FormGroup,
+    ControlLabel,
+    FormControl,
+} from 'react-bootstrap';
 
 /*** Navbar components ***/
 
@@ -42,7 +43,22 @@ const Session = props => {
     if (props.appState.isSessionsListNull()) {
         return null;
     }
-    
+
+    let semesterOrder = ['Winter', 'Spring', 'Fall', 'Year'];
+    // sort sesions in order of most recent to least recent
+    let sessions = props.appState.getSessionsList().sort((sessionA, sessionB) => {
+        if (sessionA.get('year') > sessionB.get('year')) {
+            return -1;
+        }
+        if (sessionA.get('year') < sessionB.get('year')) {
+            return 1;
+        }
+        return (
+            semesterOrder.indexOf(sessionA.get('semester')) -
+            semesterOrder.indexOf(sessionB.get('semester'))
+        );
+    });
+
     return (
         <Navbar.Form>
             <FormGroup>
@@ -50,11 +66,14 @@ const Session = props => {
                 <FormControl
                     componentClass="select"
                     onChange={event => props.appState.selectSession(event.target.value)}>
-                    <option value={null} key="session-all">-</option>
-                    {props.appState.getSessionsList().map((session, sessionId) =>
+                    <option value="" key="session-all">
+                        all
+                    </option>
+                    {sessions.map((session, sessionId) =>
                         <option value={sessionId} key={'session-' + sessionId}>
                             {session.get('semester')}&nbsp;{session.get('year')}
-                        </option>)}
+                        </option>
+                    )}
                 </FormControl>
             </FormGroup>
         </Navbar.Form>
@@ -65,7 +84,9 @@ const Auth = props =>
     <NavDropdown
         title={props.appState.getCurrentUserRole() + ':' + props.appState.getCurrentUserName()}
         id="nav-auth-dropdown">
-        <MenuItem eventKey="switch-admin" onClick={() => props.appState.setCurrentUserRole('admin')}>
+        <MenuItem
+            eventKey="switch-admin"
+            onClick={() => props.appState.setCurrentUserRole('admin')}>
             Switch to admin role
         </MenuItem>
 
@@ -77,9 +98,7 @@ const Auth = props =>
             Switch to inst role
         </MenuItem>
 
-        <MenuItem eventKey="logout">
-            Logout
-        </MenuItem>
+        <MenuItem eventKey="logout">Logout</MenuItem>
     </NavDropdown>;
 
 /*** Navbar ***/

--- a/app/javascript/cp/components/navbar.js
+++ b/app/javascript/cp/components/navbar.js
@@ -39,7 +39,7 @@ const Notifications = props => {
 };
 
 const Session = props => {
-    if (props.isSessionsListNull()) {
+    if (props.appState.isSessionsListNull()) {
         return null;
     }
     
@@ -92,7 +92,7 @@ const NavbarInst = props =>
 
         {props.appState.getCurrentUserRole() == 'admin' &&
             <Nav pullLeft>
-                <Sessions {...props} />
+                <Session {...props} />
             </Nav>}
 
         <Nav pullRight>

--- a/app/javascript/cp/components/navbar.js
+++ b/app/javascript/cp/components/navbar.js
@@ -44,21 +44,6 @@ const Session = props => {
         return null;
     }
 
-    let semesterOrder = ['Winter', 'Spring', 'Fall', 'Year'];
-    // sort sesions in order of most recent to least recent
-    let sessions = props.appState.getSessionsList().sort((sessionA, sessionB) => {
-        if (sessionA.get('year') > sessionB.get('year')) {
-            return -1;
-        }
-        if (sessionA.get('year') < sessionB.get('year')) {
-            return 1;
-        }
-        return (
-            semesterOrder.indexOf(sessionA.get('semester')) -
-            semesterOrder.indexOf(sessionB.get('semester'))
-        );
-    });
-
     return (
         <Navbar.Form>
             <FormGroup>
@@ -69,7 +54,7 @@ const Session = props => {
                     <option value="" key="session-all">
                         all
                     </option>
-                    {sessions.map((session, sessionId) =>
+                    {props.appState.getSessionsList().map((session, sessionId) =>
                         <option value={sessionId} key={'session-' + sessionId}>
                             {session.get('semester')}&nbsp;{session.get('year')}
                         </option>

--- a/app/javascript/cp/components/sessionsForm.js
+++ b/app/javascript/cp/components/sessionsForm.js
@@ -7,9 +7,17 @@ class SessionsForm extends React.Component {
             <div className="sessions">
                 <Tabs>
                     <Tab title={<b>Sessions</b>} disabled />
-                    {this.props.appState.getSessionsList().map(session =>
+                    {this.props.appState.getSessionsList().map((session, sessionId) =>
                         <Tab title={session.get('semester') + ' ' + session.get('year')}>
-                            <Form inline>
+		        <Form
+			    inline
+			    onSubmit={event => {
+				if (event.target.elements[0].value != session.get('pay')) {
+				    this.props.appState.updateSessionPay(
+					sessionId, event.target.elements[0].value);
+				}
+                                event.preventDefault();
+                            }}>
 				<b>Start date:</b>&ensp;
 				{new Date(session.get('startDate')).toDateString()}&emsp;&emsp;
 				<b>End date:</b>&ensp;
@@ -19,10 +27,18 @@ class SessionsForm extends React.Component {
                                     <InputGroup>
                                         <InputGroup.Addon>$</InputGroup.Addon>
                                         <FormControl
-                                            type="text"
+					    type="number"
+					    min="0.00"
+				            step="0.01"
                                             defaultValue={session.get('pay')}
-                                            ref={input => (this.pay = input)}
-                                        />
+				            onBlur={event => {
+						if (event.target.value != session.get('pay')) {
+						    this.props.appState.updateSessionPay(
+							sessionId,
+							event.target.value);
+						}
+					    }}
+				        />
                                     </InputGroup>
                                 </FormGroup>
                             </Form>

--- a/app/javascript/cp/components/sessionsForm.js
+++ b/app/javascript/cp/components/sessionsForm.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Panel, Tabs, Tab, Form, InputGroup, FormGroup, FormControl } from 'react-bootstrap';
+import { Panel, Tabs, Tab, InputGroup, FormControl } from 'react-bootstrap';
 
 class SessionsForm extends React.Component {
     render() {
@@ -9,39 +9,61 @@ class SessionsForm extends React.Component {
                     <Tab title={<b>Sessions</b>} disabled />
                     {this.props.appState.getSessionsList().map((session, sessionId) =>
                         <Tab title={session.get('semester') + ' ' + session.get('year')}>
-		        <Form
-			    inline
-			    onSubmit={event => {
-                                event.preventDefault();
-                                if (event.target.elements[0].value != session.get('pay')) {
-				    this.props.appState.updateSessionPay(
-					sessionId, event.target.elements[0].value);
-				}
-                            }}>
-				<b>Start date:</b>&ensp;
-				{new Date(session.get('startDate')).toDateString()}&emsp;&emsp;
-				<b>End date:</b>&ensp;
-				{new Date(session.get('endDate')).toDateString()}&emsp;&emsp;
+                            <div className="form-inline">
+                                <b>Start date:</b>&ensp;
+                                <form
+                                    className="form-group"
+                                    onSubmit={event => {
+                                        event.preventDefault();
+                                    }}>
+                                    <FormControl
+                                        type="date"
+                                        defaultValue={session.get('startDate').split('T', 1)[0]}
+                                    />
+                                </form>&emsp;&emsp;
+                                <b>End date:</b>&ensp;
+                                <form
+                                    className="form-group"
+                                    onSubmit={event => {
+                                        event.preventDefault();
+                                    }}>
+                                    <FormControl
+                                        type="date"
+                                        defaultValue={session.get('endDate').split('T', 1)[0]}
+                                    />
+                                </form>&emsp;&emsp;
                                 <b>Pay:</b>&ensp;
-                                <FormGroup>
+                                <form
+                                    className="form-group"
+                                    onSubmit={event => {
+                                        event.preventDefault();
+                                        if (event.target.elements[0].value != session.get('pay')) {
+                                            this.props.appState.updateSessionPay(
+                                                sessionId,
+                                                event.target.elements[0].value
+                                            );
+                                        }
+                                    }}>
                                     <InputGroup>
                                         <InputGroup.Addon>$</InputGroup.Addon>
                                         <FormControl
-					    type="number"
-					    min="0.00"
-				            step="0.01"
+                                            type="number"
+                                            name="pay"
+                                            min="0.00"
+                                            step="0.01"
                                             defaultValue={session.get('pay')}
-				            onBlur={event => {
-						if (event.target.value != session.get('pay')) {
-						    this.props.appState.updateSessionPay(
-							sessionId,
-							event.target.value);
-						}
-					    }}
-				        />
+                                            onBlur={event => {
+                                                if (event.target.value != session.get('pay')) {
+                                                    this.props.appState.updateSessionPay(
+                                                        sessionId,
+                                                        event.target.value
+                                                    );
+                                                }
+                                            }}
+                                        />
                                     </InputGroup>
-                                </FormGroup>
-                            </Form>
+                                </form>
+                            </div>
                         </Tab>
                     )}
                 </Tabs>

--- a/app/javascript/cp/components/sessionsForm.js
+++ b/app/javascript/cp/components/sessionsForm.js
@@ -10,24 +10,18 @@ class SessionsForm extends React.Component {
                     {this.props.appState.getSessionsList().map(session =>
                         <Tab title={session.get('semester') + ' ' + session.get('year')}>
                             <Form inline>
-                                <b>Start date:</b>&ensp;{new Date(session.get('startDate')).toDateString()}&emsp;&emsp;
-                                <b>End date:</b>&ensp;{new Date(session.get('endDate')).toDateString()}&emsp;&emsp;
+				<b>Start date:</b>&ensp;
+				{new Date(session.get('startDate')).toDateString()}&emsp;&emsp;
+				<b>End date:</b>&ensp;
+				{new Date(session.get('endDate')).toDateString()}&emsp;&emsp;
                                 <b>Pay:</b>&ensp;
-                                <FormGroup
-                                    validationState={
-                                        this.pay == undefined || this.pay.value == null
-                                            ? null
-                                            : /[0-9]+\.[0-9]{2}/.test(this.pay.value)
-                                              ? 'success'
-                                              : 'error'
-                                    }>
+                                <FormGroup>
                                     <InputGroup>
                                         <InputGroup.Addon>$</InputGroup.Addon>
                                         <FormControl
                                             type="text"
                                             defaultValue={session.get('pay')}
                                             ref={input => (this.pay = input)}
-                                            pattern="[0-9]+\.[0-9]{2}"
                                         />
                                     </InputGroup>
                                 </FormGroup>

--- a/app/javascript/cp/components/sessionsForm.js
+++ b/app/javascript/cp/components/sessionsForm.js
@@ -5,7 +5,7 @@ class SessionsForm extends React.Component {
     render() {
         return (
             <div className="sessions">
-                <Tabs>
+                <Tabs id="sessions-tabs">
                     <Tab title={<b>Sessions</b>} disabled />
                     {this.props.appState.getSessionsList().map((session, sessionId) =>
                         <Tab title={session.get('semester') + ' ' + session.get('year')}>

--- a/app/javascript/cp/components/sessionsForm.js
+++ b/app/javascript/cp/components/sessionsForm.js
@@ -12,11 +12,11 @@ class SessionsForm extends React.Component {
 		        <Form
 			    inline
 			    onSubmit={event => {
-				if (event.target.elements[0].value != session.get('pay')) {
+                                event.preventDefault();
+                                if (event.target.elements[0].value != session.get('pay')) {
 				    this.props.appState.updateSessionPay(
 					sessionId, event.target.elements[0].value);
 				}
-                                event.preventDefault();
                             }}>
 				<b>Start date:</b>&ensp;
 				{new Date(session.get('startDate')).toDateString()}&emsp;&emsp;

--- a/app/javascript/cp/components/sessionsForm.js
+++ b/app/javascript/cp/components/sessionsForm.js
@@ -1,73 +1,79 @@
 import React from 'react';
-import { Panel, Tabs, Tab, InputGroup, FormControl } from 'react-bootstrap';
+import { Panel, Form, FormGroup, ControlLabel, InputGroup, FormControl } from 'react-bootstrap';
 
 class SessionsForm extends React.Component {
     render() {
         return (
-            <div className="sessions">
-                <Tabs id="sessions-tabs">
-                    <Tab title={<b>Sessions</b>} disabled />
-                    {this.props.appState.getSessionsList().map((session, sessionId) =>
-                        <Tab title={session.get('semester') + ' ' + session.get('year')}>
-                            <div className="form-inline">
-                                <b>Start date:</b>&ensp;
-                                <form
-                                    className="form-group"
-                                    onSubmit={event => {
-                                        event.preventDefault();
-                                    }}>
-                                    <FormControl
-                                        type="date"
-                                        defaultValue={session.get('startDate').split('T', 1)[0]}
-                                    />
-                                </form>&emsp;&emsp;
-                                <b>End date:</b>&ensp;
-                                <form
-                                    className="form-group"
-                                    onSubmit={event => {
-                                        event.preventDefault();
-                                    }}>
-                                    <FormControl
-                                        type="date"
-                                        defaultValue={session.get('endDate').split('T', 1)[0]}
-                                    />
-                                </form>&emsp;&emsp;
-                                <b>Pay:</b>&ensp;
-                                <form
-                                    className="form-group"
-                                    onSubmit={event => {
-                                        event.preventDefault();
-                                        if (event.target.elements[0].value != session.get('pay')) {
-                                            this.props.appState.updateSessionPay(
-                                                sessionId,
-                                                event.target.elements[0].value
-                                            );
-                                        }
-                                    }}>
-                                    <InputGroup>
-                                        <InputGroup.Addon>$</InputGroup.Addon>
-                                        <FormControl
-                                            type="number"
-                                            name="pay"
-                                            min="0.00"
-                                            step="0.01"
-                                            defaultValue={session.get('pay')}
-                                            onBlur={event => {
-                                                if (event.target.value != session.get('pay')) {
-                                                    this.props.appState.updateSessionPay(
-                                                        sessionId,
-                                                        event.target.value
-                                                    );
-                                                }
-                                            }}
-                                        />
-                                    </InputGroup>
-                                </form>
-                            </div>
-                        </Tab>
-                    )}
-                </Tabs>
-            </div>
+            <Panel className="sessions">
+                <Form
+                    inline
+                    onSubmit={event => {
+                        event.preventDefault();
+                        if (
+                            this.pay.value !=
+                            this.props.appState.getSessionsList().getIn([this.session.value, 'pay'])
+                        ) {
+                            this.props.appState.updateSessionPay(
+                                this.session.value,
+                                this.pay.value
+                            );
+                        }
+                    }}>
+                    <FormGroup>
+                        <ControlLabel>Session:</ControlLabel>&ensp;
+                        <FormControl
+                            id="session"
+                            componentClass="select"
+                            inputRef={ref => {
+                                this.session = ref;
+                            }}
+                            onChange={event => {
+                                this.props.appState.selectSession(event.target.value);
+                                let pay = this.props.appState
+                                    .getSessionsList()
+                                    .getIn([event.target.value, 'pay']);
+                                this.pay.value = pay ? pay : null;
+                            }}>
+                            <option value="" key="session-all">
+                                all
+                            </option>
+                            {this.props.appState.getSessionsList().map((session, sessionId) =>
+                                <option value={sessionId}>
+                                    {session.get('semester')}&nbsp;{session.get('year')}
+                                </option>
+                            )}
+                        </FormControl>
+                    </FormGroup>
+                    <FormGroup id="pay">
+                        <ControlLabel>Pay:</ControlLabel>&ensp;
+                        <InputGroup>
+                            <InputGroup.Addon>$</InputGroup.Addon>
+                            <FormControl
+                                type="number"
+                                min="0.00"
+                                step="0.01"
+                                disabled={this.props.appState.getSelectedSession() == ''}
+                                inputRef={ref => {
+                                    this.pay = ref;
+                                }}
+                                onBlur={event => {
+                                    if (
+                                        event.target.value !=
+                                        this.props.appState
+                                            .getSessionsList()
+                                            .getIn([this.session.value, 'pay'])
+                                    ) {
+                                        this.props.appState.updateSessionPay(
+                                            this.session.value,
+                                            event.target.value
+                                        );
+                                    }
+                                }}
+                            />
+                        </InputGroup>
+                    </FormGroup>
+                </Form>
+            </Panel>
         );
     }
 }

--- a/app/javascript/cp/fetch.js
+++ b/app/javascript/cp/fetch.js
@@ -100,6 +100,7 @@ function onFetchOffersSuccess(resp) {
             ddahStatus: offer.ddah_status,
             sentAt: offer.send_date,
             printedAt: offer.print_time,
+            link: offer.link,
         };
     });
 
@@ -210,18 +211,6 @@ function sendContracts(offers) {
             showMessageInJsonBody(resp);
         }
     );
-}
-
-// email applicants
-function email(emails) {
-    let ref =
-        emails.length == 1
-            ? 'mailto:' + emails[0] // if there is only a single recipient, send normally
-            : 'mailto:?bcc=' + emails.join(';'); // if there are multiple recipients, bcc all
-
-    var a = document.createElement('a');
-    a.href = ref;
-    a.click();
 }
 
 // nag applicants
@@ -368,7 +357,6 @@ export {
     importOffers,
     importAssignments,
     sendContracts,
-    email,
     nag,
     setHrProcessed,
     setDdahAccepted,

--- a/app/javascript/cp/fetch.js
+++ b/app/javascript/cp/fetch.js
@@ -77,7 +77,7 @@ const getOffers = () => getHelper('/offers')
 
 const getSessions = () => getHelper('/sessions')
       .then(resp => resp.json())
-      .then(onFetchOffersSuccess)
+      .then(onFetchSessionsSuccess)
       .catch(defaultFailure);
 
 /* Success callbacks for resource GETters */

--- a/app/javascript/cp/fetch.js
+++ b/app/javascript/cp/fetch.js
@@ -23,7 +23,7 @@ function showMessageInJsonBody(resp) {
 function fetchHelper(URL, init) {
     return fetch(URL, init)
         .then(function(resp) {
-            if (response.ok) {
+            if (resp.ok) {
                 return Promise.resolve(resp);
             }
             return Promise.reject(resp);
@@ -70,15 +70,14 @@ function putHelper(URL, body) {
 
 /* Resource GETters */
 
-const getOffers = () => getHelper('/offers')
-      .then(resp => resp.json())
-      .then(onFetchOffersSuccess)
-      .catch(defaultFailure);
+const getOffers = () =>
+    getHelper('/offers').then(resp => resp.json()).then(onFetchOffersSuccess).catch(defaultFailure);
 
-const getSessions = () => getHelper('/sessions')
-      .then(resp => resp.json())
-      .then(onFetchSessionsSuccess)
-      .catch(defaultFailure);
+const getSessions = () =>
+    getHelper('/sessions')
+        .then(resp => resp.json())
+        .then(onFetchSessionsSuccess)
+        .catch(defaultFailure);
 
 /* Success callbacks for resource GETters */
 
@@ -153,8 +152,8 @@ function fetchAll() {
 function importAssignments() {
     appState.setImporting(true);
 
-    postHelper('/import/locked-assignments', {})
-        .then(() => {
+    postHelper('/import/locked-assignments', {}).then(
+        () => {
             appState.setImporting(false, true);
 
             appState.setFetchingOffersList(true);
@@ -168,15 +167,16 @@ function importAssignments() {
         resp => {
             appState.setImporting(false);
             showMessageInJsonBody(resp);
-        });
+        }
+    );
 }
 
 // send CHASS offers data
 function importOffers(data) {
     appState.setImporting(true);
 
-    postHelper('/import/offers', { chass_offers: data })
-        .then(() => {
+    postHelper('/import/offers', { chass_offers: data }).then(
+        () => {
             appState.setImporting(false, true);
 
             appState.setFetchingOffersList(true);
@@ -190,13 +190,14 @@ function importOffers(data) {
         resp => {
             appState.setImporting(false);
             showMessageInJsonBody(resp);
-        });
+        }
+    );
 }
 
 // send contracts
 function sendContracts(offers) {
-    postHelper('/offers/send-contracts', { offers: offers })
-        .then(() => {
+    postHelper('/offers/send-contracts', { offers: offers }).then(
+        () => {
             appState.setFetchingOffersList(true);
             getOffers()
                 .then(offers => {
@@ -207,7 +208,8 @@ function sendContracts(offers) {
         },
         resp => {
             showMessageInJsonBody(resp);
-        });
+        }
+    );
 }
 
 // email applicants
@@ -224,8 +226,8 @@ function email(emails) {
 
 // nag applicants
 function nag(offers) {
-    postHelper('/offers/nag', { contracts: offers })
-        .then(() => {
+    postHelper('/offers/nag', { contracts: offers }).then(
+        () => {
             appState.setFetchingOffersList(true);
             getOffers()
                 .then(offers => {
@@ -236,13 +238,14 @@ function nag(offers) {
         },
         resp => {
             showMessageInJsonBody(resp);
-        });
+        }
+    );
 }
 
 // mark contracts as hr_processed
 function setHrProcessed(offers) {
-    putHelper('/offers/batch-update', { offers: offers, hr_status: 'Processed' })
-        .then(() => {
+    putHelper('/offers/batch-update', { offers: offers, hr_status: 'Processed' }).then(
+        () => {
             appState.setFetchingOffersList(true);
             getOffers()
                 .then(offers => {
@@ -253,13 +256,14 @@ function setHrProcessed(offers) {
         },
         resp => {
             showMessageInJsonBody(resp);
-        });
+        }
+    );
 }
 
 // mark contracts as ddah_accepted
 function setDdahAccepted(offers) {
-    putHelper('/offers/batch-update', { offers: offers, ddah_status: 'Accepted' })
-        .then(() => {
+    putHelper('/offers/batch-update', { offers: offers, ddah_status: 'Accepted' }).then(
+        () => {
             appState.setFetchingOffersList(true);
             getOffers()
                 .then(offers => {
@@ -270,7 +274,8 @@ function setDdahAccepted(offers) {
         },
         resp => {
             showMessageInJsonBody(resp);
-        });
+        }
+    );
 }
 
 // show the contract for this offer in a new window, as an applicant would see it
@@ -295,36 +300,8 @@ function withdrawOffers(offers) {
     // create an array of promises for each offer being withdrawn
     Promise.all(
         offers.map(offer => postHelper('/offers/' + offer + '/decision/withdraw', {}))
-    ).then(() => {
-        appState.setFetchingOffersList(true);
-        getOffers()
-            .then(offers => {
-                appState.setOffersList(fromJS(offers));
-                appState.setFetchingOffersList(false, true);
-            })
-            .catch(() => appState.setFetchingOffersList(false));
-    },
-    resp => {
-        showMessageInJsonBody(resp);
-    });
-}
-
-// print contracts
-function print(offers) {
-    let postPromise = postHelper('/offers/print', { contracts: offers, update: true })
-        .then(resp => resp.blob())
-        .catch(defaultFailure);
-
-    postPromise
-        .then(blob => {
-            let fileURL = URL.createObjectURL(blob);
-            let pdfWindow = window.open(fileURL);
-            pdfWindow.onclose = () => URL.revokeObjectURL(fileURL);
-            pdfWindow.document.onload = pdfWindow.print();
-        });
-
-    postPromise
-        .then(() => {
+    ).then(
+        () => {
             appState.setFetchingOffersList(true);
             getOffers()
                 .then(offers => {
@@ -335,13 +312,43 @@ function print(offers) {
         },
         resp => {
             showMessageInJsonBody(resp);
-        });
+        }
+    );
+}
+
+// print contracts
+function print(offers) {
+    let postPromise = postHelper('/offers/print', { contracts: offers, update: true })
+        .then(resp => resp.blob())
+        .catch(defaultFailure);
+
+    postPromise.then(blob => {
+        let fileURL = URL.createObjectURL(blob);
+        let pdfWindow = window.open(fileURL);
+        pdfWindow.onclose = () => URL.revokeObjectURL(fileURL);
+        pdfWindow.document.onload = pdfWindow.print();
+    });
+
+    postPromise.then(
+        () => {
+            appState.setFetchingOffersList(true);
+            getOffers()
+                .then(offers => {
+                    appState.setOffersList(fromJS(offers));
+                    appState.setFetchingOffersList(false, true);
+                })
+                .catch(() => appState.setFetchingOffersList(false));
+        },
+        resp => {
+            showMessageInJsonBody(resp);
+        }
+    );
 }
 
 // change session pay
-function updateSessionPay(session, pay){
-    putHelper('/sessions/' + session, { pay: pay })
-        .then(() => {
+function updateSessionPay(session, pay) {
+    putHelper('/sessions/' + session, { pay: pay }).then(
+        () => {
             appState.setFetchingSessionsList(true);
             getSessions()
                 .then(sessions => {
@@ -352,7 +359,8 @@ function updateSessionPay(session, pay){
         },
         resp => {
             showMessageInJsonBody(resp);
-        });
+        }
+    );
 }
 
 export {

--- a/app/javascript/tapp/appState.js
+++ b/app/javascript/tapp/appState.js
@@ -569,7 +569,7 @@ class AppState {
     addInstructor(courseId, instructorId) {
         let val = this.getCoursesList().get(courseId.toString()).get('instructors').toJS();
         val.push(parseInt(instructorId));
-        fetch.updateCourse(courseId, { instructors: val }, 'instructors');
+        fetch.updateCourse(courseId, { instructors: val });
     }
 
     // check if any data is being fetched
@@ -886,7 +886,7 @@ class AppState {
     importEnrolment(data) {
         fetch.importEnrolment(data);
     }
-	
+        
     importing() {
         return this.get('importing') > 0;
     }
@@ -934,7 +934,7 @@ class AppState {
         // thinks they are strings
         let val = this.getCoursesList().get(courseId.toString()).get('instructors').toJS();
         val.splice(index, 1);
-        fetch.updateCourse(courseId, { instructors: val }, 'instructors');
+        fetch.updateCourse(courseId, { instructors: val });
     }
 
     setApplicantsList(list) {
@@ -1073,9 +1073,9 @@ class AppState {
         fetch.unlockAssignment(applicant, assignment);
     }
 
-    updateCourse(courseId, val, props) {
+    updateCourse(courseId, val, attr) {
         let data = {};
-        switch (props) {
+        switch (attr) {
             case 'estimatedPositions':
                 data['estimated_count'] = val;
                 break;
@@ -1098,7 +1098,7 @@ class AppState {
                 data['num_waitlisted'] = val;
                 break;
         }
-        fetch.updateCourse(courseId, data, props);
+        fetch.updateCourse(courseId, data);
     }
 }
 

--- a/app/javascript/tapp/appState.js
+++ b/app/javascript/tapp/appState.js
@@ -833,7 +833,7 @@ class AppState {
 
     // get a sorted list of course codes
     getCourseCodes() {
-        return this.getCoursesList().valueSeq().map(course => course.get('code')).sort();
+        return this.getCoursesList().map(course => course.get('code')).flip().keySeq().sort();
     }
 
     getCourseCodeById(course) {

--- a/app/javascript/tapp/fetch.js
+++ b/app/javascript/tapp/fetch.js
@@ -22,7 +22,7 @@ function showMessageInJsonBody(resp) {
 function fetchHelper(URL, init) {
     return fetch(URL, init)
         .then(function(resp) {
-            if (response.ok) {
+            if (resp.ok) {
                 return Promise.resolve(resp);
             }
             return Promise.reject(resp);
@@ -69,30 +69,35 @@ function putHelper(URL, body) {
 
 /* Resource GETters */
 
-const getApplicants = () => getHelper('/applicants')
-      .then(resp => resp.json())
-      .then(onFetchApplicantsSuccess)
-      .catch(defaultFailure);
+const getApplicants = () =>
+    getHelper('/applicants')
+        .then(resp => resp.json())
+        .then(onFetchApplicantsSuccess)
+        .catch(defaultFailure);
 
-const getApplications = () => getHelper('/applications')
-      .then(resp => resp.json())
-      .then(onFetchApplicationsSuccess)
-      .catch(defaultFailure);
+const getApplications = () =>
+    getHelper('/applications')
+        .then(resp => resp.json())
+        .then(onFetchApplicationsSuccess)
+        .catch(defaultFailure);
 
-const getCourses = () => getHelper('/positions')
-      .then(resp => resp.json())
-      .then(onFetchPositionsSuccess)
-      .catch(defaultFailure);
+const getCourses = () =>
+    getHelper('/positions')
+        .then(resp => resp.json())
+        .then(onFetchCoursesSuccess)
+        .catch(defaultFailure);
 
-const getAssignments = () => getHelper('/assignments')
-      .then(resp => resp.json())
-      .then(onFetchAssignmentsSuccess)
-      .catch(defaultFailure);
+const getAssignments = () =>
+    getHelper('/assignments')
+        .then(resp => resp.json())
+        .then(onFetchAssignmentsSuccess)
+        .catch(defaultFailure);
 
-const getInstructors = () => getHelper('/instructors')
-      .then(resp => resp.json())
-      .then(onFetchInstructorsSuccess)
-      .catch(defaultFailure);
+const getInstructors = () =>
+    getHelper('/instructors')
+        .then(resp => resp.json())
+        .then(onFetchInstructorsSuccess)
+        .catch(defaultFailure);
 
 /* Success callbacks for resource GETters */
 
@@ -301,96 +306,96 @@ function fetchAll() {
 
 // create a new assignment
 function postAssignment(applicant, course, hours) {
-    postHelper('/applicants/' + applicant + '/assignments',
-               { position_id: course, hours: hours })
-        .then(() => {
-            appState.setFetchingAssignmentsList(true);
-            getAssignments()
-                .then(assignments => {
-                    appState.setAssignmentsList(assignments);
-                    appState.setFetchingAssignmentsList(false, true);
-                })
-                .catch(() => appState.setFetchingAssignmentsList(false));
-        });
+    postHelper('/applicants/' + applicant + '/assignments', {
+        position_id: course,
+        hours: hours,
+    }).then(() => {
+        appState.setFetchingAssignmentsList(true);
+        getAssignments()
+            .then(assignments => {
+                appState.setAssignmentsList(assignments);
+                appState.setFetchingAssignmentsList(false, true);
+            })
+            .catch(() => appState.setFetchingAssignmentsList(false));
+    });
 }
 
 // remove an assignment
 function deleteAssignment(applicant, assignment) {
-    deleteHelper('/applicants/' + applicant + '/assignments/' + assignment)
-        .then(() => {
-            appState.setFetchingAssignmentsList(true);
-            getAssignments()
-                .then(assignments => {
-                    appState.setAssignmentsList(assignments);
-                    appState.setFetchingAssignmentsList(false, true);
-                })
-                .catch(() => appState.setFetchingAssignmentsList(false));
-        });
+    deleteHelper('/applicants/' + applicant + '/assignments/' + assignment).then(() => {
+        appState.setFetchingAssignmentsList(true);
+        getAssignments()
+            .then(assignments => {
+                appState.setAssignmentsList(assignments);
+                appState.setFetchingAssignmentsList(false, true);
+            })
+            .catch(() => appState.setFetchingAssignmentsList(false));
+    });
 }
 
 // add/update the notes for an applicant
 function noteApplicant(applicant, notes) {
-    putHelper('/applicants/' + applicant, { commentary: notes })
-        .then(() => {
-            appState.setFetchingApplicantsList(true);
-            getApplicants()
-                .then(applicants => {
-                    appState.setApplicantsList(applicants);
-                    appState.setFetchingApplicantsList(false, true);
-                })
-                .catch(() => appState.setFetchingApplicantsList(false));
-        });
+    putHelper('/applicants/' + applicant, { commentary: notes }).then(() => {
+        appState.setFetchingApplicantsList(true);
+        getApplicants()
+            .then(applicants => {
+                appState.setApplicantsList(applicants);
+                appState.setFetchingApplicantsList(false, true);
+            })
+            .catch(() => appState.setFetchingApplicantsList(false));
+    });
 }
 
 // update the number of hours for an assignment
 function updateAssignmentHours(applicant, assignment, hours) {
-    putHelper('/applicants/' + applicant + '/assignments/' + assignment, { hours: hours })
-        .then(() => {
-            appState.setFetchingAssignmentsList(true);
-            getAssignments()
-                .then(assignments => {
-                    appState.setAssignmentsList(assignments);
-                    appState.setFetchingAssignmentsList(false, true);
-                })
-                .catch(() => appState.setFetchingAssignmentsList(false));
-        });
+    putHelper('/applicants/' + applicant + '/assignments/' + assignment, {
+        hours: hours,
+    }).then(() => {
+        appState.setFetchingAssignmentsList(true);
+        getAssignments()
+            .then(assignments => {
+                appState.setAssignmentsList(assignments);
+                appState.setFetchingAssignmentsList(false, true);
+            })
+            .catch(() => appState.setFetchingAssignmentsList(false));
+    });
 }
 
 // update attribute(s) of a course
 function updateCourse(courseId, data) {
-    putHelper('/positions/' + courseId, data)
-        .then(() => {
-            appState.setFetchingCoursesList(true);
-            getCourses()
-                .then(courses => {
-                    appState.setCoursesList(courses);
-                    appState.setFetchingCoursesList(false, true);
-                })
-                .catch(() => appState.setFetchingCoursesList(false));
-        });
+    putHelper('/positions/' + courseId, data).then(() => {
+        appState.setFetchingCoursesList(true);
+        getCourses()
+            .then(courses => {
+                appState.setCoursesList(courses);
+                appState.setFetchingCoursesList(false, true);
+            })
+            .catch(() => appState.setFetchingCoursesList(false));
+    });
 }
 
 // send CHASS data
 function importChass(data) {
     appState.setImporting(true);
 
-    postHelper('/import/chass', { chass_json: data })
-        .then(() => {
+    postHelper('/import/chass', { chass_json: data }).then(
+        () => {
             appState.setImporting(false, true);
             fetchAll();
         },
         resp => {
             appState.setImporting(false);
             showMessageInJsonBody(resp);
-        });
+        }
+    );
 }
 
 // send enrolment data
 function importEnrolment(data) {
     appState.setImporting(true);
 
-    postHelper('/import/enrollment', { enrollment_data: data })
-        .then(() => {
+    postHelper('/import/enrollment', { enrollment_data: data }).then(
+        () => {
             appState.setImporting(false, true);
 
             appState.setFetchingCoursesList(true);
@@ -404,27 +409,28 @@ function importEnrolment(data) {
         resp => {
             appState.setImporting(false);
             showMessageInJsonBody(resp);
-        });
+        }
+    );
 }
 
 // unlock a single assignment
 function unlockAssignment(applicant, assignment) {
-    putHelper('/applicants/' + applicant + '/assignments/' + assignment, { export_date: null })
-        .then(() => {
-            appState.setFetchingAssignmentsList(true);
-            getAssignments()
-                .then(assignments => {
-                    appState.setAssignmentsList(assignments);
-                    appState.setFetchingAssignmentsList(false, true);
-                })
-                .catch(() => appState.setFetchingAssignmentsList(false));
-        });
+    putHelper('/applicants/' + applicant + '/assignments/' + assignment, {
+        export_date: null,
+    }).then(() => {
+        appState.setFetchingAssignmentsList(true);
+        getAssignments()
+            .then(assignments => {
+                appState.setAssignmentsList(assignments);
+                appState.setFetchingAssignmentsList(false, true);
+            })
+            .catch(() => appState.setFetchingAssignmentsList(false));
+    });
 }
 
 // export offers from CHASS (locking the corresponding assignments)
 function exportOffers(round) {
-    let exportPromise = fetchHelper('/export/chass/' + round, {})
-        .catch(defaultFailure);
+    let exportPromise = fetchHelper('/export/chass/' + round, {}).catch(defaultFailure);
 
     let filename;
     exportPromise
@@ -446,16 +452,15 @@ function exportOffers(round) {
             URL.revokeObjectURL(url);
         });
 
-    exportPromise
-        .then(() => {
-            appState.setFetchingAssignmentsList(true);
-            getAssignments()
-                .then(assignments => {
-                    appState.setAssignmentsList(assignments);
-                    appState.setFetchingAssignmentsList(false, true);
-                })
-                .catch(() => appState.setFetchingAssignmentsList(false));
-        });
+    exportPromise.then(() => {
+        appState.setFetchingAssignmentsList(true);
+        getAssignments()
+            .then(assignments => {
+                appState.setAssignmentsList(assignments);
+                appState.setFetchingAssignmentsList(false, true);
+            })
+            .catch(() => appState.setFetchingAssignmentsList(false));
+    });
 }
 
 export {


### PR DESCRIPTION
Port of CP PR #34: https://github.com/uoft-tapp/cp/pull/34

- [x] checkbox range selection
- [ ] ~table in-column searching~
- [x] email templating with mangled applicant contract URL 
~doesn't seem to be possible, since fetching the mangled contract URL would expose a vulnerability
@michellemtchai what do you think?~
- [x] session selection
- [x] modifying sessional pay

@michellemtchai:
> @gabriellesc I can open up an admin only route `GET /decision/:utorid/:position_id` like before. This way the students gets their mangled routes and we get the readable routes for the admin. 

@gabriellesc:
> @michellemtchai what would that route return?

@michellemtchai:
> @gabriellesc It would render the student-facing view. It's the same page the applicant sees when they click on the mangled link.

@gabriellesc:
> @michellemtchai This would be for the purpose of inserting the mangled link into an email to send to people, not just for seeing the student-facing view

@michellemtchai:
> @gabriellesc That can be an extra route or it can be part of the `/offers` fetch. Which do you prefer?