### PR TITLE
split batch CP action into 2 parts

### DIFF
--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -30,14 +30,8 @@ class OffersController < ApplicationController
 
   def can_send_contract
     offer = Offer.find(params[:offer_id])
-    if offer
-      if !offer[:send_date]
-        render status: 200
-      else
-        render status: 404, json: {message: "Error: This offer has already been sent."}
-      end
-    else
-      render status: 404, json: {message: "Error: No such offer."}
+    if offer[:send_date]
+      render status: 404, json: {message: "Error: This offer has already been sent."}
     end
   end
 
@@ -66,14 +60,8 @@ class OffersController < ApplicationController
 
   def can_nag
     offer = Offer.find(params[:offer_id])
-    if offer
-      if offer[:status] == "Pending"
-        render status: 200
-      else
-        render status: 404, json: {message: "Error: This offer is not in Pending."}
-      end
-    else
-      render status: 404, json: {message: "Error: No such offer."}
+    if offer[:status] != "Pending"
+      render status: 404, json: {message: "Error: This offer is not in Pending."}
     end
   end
 
@@ -101,14 +89,8 @@ class OffersController < ApplicationController
 
   def can_print
     offer = Offer.find(params[:offer_id])
-    if offer
-      if offer[:status] != "Unsent" && offer[:status] != "Withdrawn"
-        render status: 200
-      else
-        render status: 404, json: {message: "Error: This offer is not in Pending."}
-      end
-    else
-      render status: 404, json: {message: "Error: No such offer."}
+    if offer[:status] != "Accepted"
+      render status: 404, json: {message: "Error: This offer has not been accepted."}
     end
   end
 

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -12,6 +12,14 @@ class OffersController < ApplicationController
     render json: offer.format
   end
 
+  def can_hr_update
+    offers_accepted(params[:offers])
+  end
+
+  def can_ddah_update
+    offers_accepted(params[:offers])
+  end
+
   def update
     if params[:id] == "batch-update"
       if params[:offers]
@@ -100,16 +108,7 @@ class OffersController < ApplicationController
   end
 
   def can_print
-    invalid = []
-    params[:contracts].each do |offer_id|
-      offer = Offer.find(offer_id)
-      if offer[:status] != "Accepted"
-        invalid.push(offer[:id])
-      end
-    end
-    if invalid.length > 0
-      render status: 404, json: {invalid_offers: invalid}
-    end
+    offers_accepted(params[:contracts])
   end
 
   def combine_contracts_print
@@ -196,7 +195,7 @@ class OffersController < ApplicationController
     elsif offer[:status] == "Unsent"
       render status: 404, json: {success: false, message: "You cannot #{status[:action]} an unsent offer."}
     else
-      render status: 404, json: {success: false, message: "You cannot reject this offer. This offer has already been #{offer[:status].downcase}."}
+      render status: 404, json: {success: false, message: "You cannot #{status[:action]} this offer. This offer has already been #{offer[:status].downcase}."}
     end
   end
 
@@ -238,5 +237,18 @@ class OffersController < ApplicationController
   def set_domain
     ENV["domain"] = request.base_url
   end
-  
+
+  def offers_accepted(offers)
+    invalid = []
+    offers.each do |offer_id|
+      offer = Offer.find(offer_id)
+      if offer[:status] != "Accepted"
+        invalid.push(offer[:id])
+      end
+    end
+    if invalid.length > 0
+      render status: 404, json: {invalid_offers: invalid}
+    end
+  end
+
 end

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -28,89 +28,101 @@ class OffersController < ApplicationController
     end
   end
 
-  def send_contracts
-    errors = ["Exceptions:"]
-    if params[:offers]
-      params[:offers].each do |id|
-        offer = Offer.find(id)
-        if !offer[:send_date]
-          if ENV['RAILS_ENV'] != 'test'
-            begin
-              '''
-               We create mangled, which is a hash of the data from get_utorid_position
-               the data from get_utorid_position is a json that can be reused
-               on the /pb/:mangled routes, where :mangled = mangled.
-               This is where we mangled our routes so that an attacker can\'t
-               see how to masquerade as another applicant.
-               get_route(mangled) creates the link that we send to the applicant,
-               so that they can see the view for making decision on whether or not
-               to accept an offer.
-              '''
-              mangled = crypt(get_utorid_position(offer.format), id)
-              offer.update_attributes!(link: mangled)
-              CpMailer.contract_email(offer.format, get_route(mangled)).deliver_now
-            rescue StandardError => e
-              errors.push("Could not send a contract to #{offer[:applicant][:email]}.")
-            end
-          end
-          offer.update_attributes!({status: "Pending", send_date: DateTime.now.to_s})
-        else
-          errors.push("You've already sent out a contract to #{offer.format[:applicant][:email]}.")
-        end
+  def can_send_contract
+    offer = Offer.find(params[:offer_id])
+    if offer
+      if !offer[:send_date]
+        render status: 200
+      else
+        render status: 404, json: {message: "Error: This offer has already been sent."}
       end
-    end
-    if errors.length == 1
-      render status: 200, json: {message: "You've successfully sent out all the contracts."}
     else
-      render status: 404, json: {message: errors.join("\n")}
+      render status: 404, json: {message: "Error: No such offer."}
+    end
+  end
+
+  def send_contracts
+    params[:offers].each do |id|
+      offer = Offer.find(id)
+        if ENV['RAILS_ENV'] != 'test'
+          '''
+            We create mangled, which is a hash of the data from get_utorid_position
+            the data from get_utorid_position is a json that can be reused
+            on the /pb/:mangled routes, where :mangled = mangled.
+            This is where we mangled our routes so that an attacker can\'t
+            see how to masquerade as another applicant.
+            get_route(mangled) creates the link that we send to the applicant,
+            so that they can see the view for making decision on whether or not
+            to accept an offer.
+          '''
+          mangled = crypt(get_utorid_position(offer.format), id)
+          offer.update_attributes!(link: mangled)
+          CpMailer.contract_email(offer.format, get_route(mangled)).deliver_now
+        end
+        offer.update_attributes!({status: "Pending", send_date: DateTime.now.to_s})
+    end
+    render status: 200, json: {message: "You've successfully sent out all the contracts."}
+  end
+
+  def can_nag
+    offer = Offer.find(params[:offer_id])
+    if offer
+      if offer[:status] == "Pending"
+        render status: 200
+      else
+        render status: 404, json: {message: "Error: This offer is not in Pending."}
+      end
+    else
+      render status: 404, json: {message: "Error: No such offer."}
     end
   end
 
   def batch_email_nags
-    exceptions = ["Exceptions:"]
-    if params[:contracts] && params[:contracts]!=""
-      params[:contracts].each do |id|
-        offer = Offer.find(id)
-        if offer
-          if offer[:status] == "Pending"
-            offer.increment!(:nag_count, 1)
-            if ENV['RAILS_ENV'] != 'test'
-              '''
-               We create mangled, which is a hash of the data from get_utorid_position
-               the data from get_utorid_position is a json that can be reused
-               on the /pb/:mangled routes, where :mangled = mangled.
-               This is where we mangled our routes so that an attacker can`t
-               see how to masquerade as another applicant.
-               get_route(mangled) creates the link that we send to the applicant,
-               so that they can see the view for making decision on whether or not
-               to accept an offer.
-              '''
-              mangled = offer[:link]
-              CpMailer.nag_email(offer.format, get_route(mangled)).deliver_now
-            end
-          else
-            offer = offer.format
-            exceptions.push("- Applicant #{offer[:applicant][:first_name]} #{offer[:applicant][:last_name]}'s nag for Position #{offer[:position]} was not sent because it is not in Pending status.")
-          end
-        end
+    params[:contracts].each do |id|
+      offer = Offer.find(id)
+      offer.increment!(:nag_count, 1)
+      if ENV['RAILS_ENV'] != 'test'
+        '''
+         We create mangled, which is a hash of the data from get_utorid_position
+         the data from get_utorid_position is a json that can be reused
+         on the /pb/:mangled routes, where :mangled = mangled.
+         This is where we mangled our routes so that an attacker can`t
+         see how to masquerade as another applicant.
+         get_route(mangled) creates the link that we send to the applicant,
+         so that they can see the view for making decision on whether or not
+         to accept an offer.
+        '''
+        mangled = offer[:link]
+        CpMailer.nag_email(offer.format, get_route(mangled)).deliver_now
       end
-      if exceptions.length == 1
-        render json: {message: "You've sent the nag emails."}
+    end
+    render json: {message: "You've sent the nag emails."}
+  end
+
+  def can_print
+    offer = Offer.find(params[:offer_id])
+    if offer
+      if offer[:status] != "Unsent" && offer[:status] != "Withdrawn"
+        render status: 200
       else
-        render status: 404, json: {message: exceptions.join("\n")}
+        render status: 404, json: {message: "Error: This offer is not in Pending."}
       end
+    else
+      render status: 404, json: {message: "Error: No such offer."}
     end
   end
 
   def combine_contracts_print
-    if params[:contracts] && params[:contracts]!=""
-      offers = get_printable_data(params[:contracts])
+    offers = []
+    params[:contracts].each do |offer_id|
       if params[:update]
-        update_print_status(offers)
+        update_print_status(offer_id)
       end
-      generator = ContractGenerator.new(offers, true)
-      send_data generator.render, filename: "contracts.pdf", disposition: "inline"
+      offer = Offer.find(offer_id)
+      offers.push(offer.format)
     end
+    generator = ContractGenerator.new(offers, true)
+    send_data generator.render, filename: "contracts.pdf", disposition: "inline"
   end
 
   '''
@@ -163,25 +175,12 @@ class OffersController < ApplicationController
     end
   end
 
-  def get_printable_data(contracts)
-    offers = []
-    contracts.each do |id|
-      offer = Offer.find(id)
-      if offer
-        offers.push(offer.format)
-      end
-    end
-    return offers
-  end
-
-  def update_print_status(offers)
-    offers.each do |offer|
-      offer = Offer.find(offer[:id])
-      if offer[:hr_status] == "Processed"
-        offer.update_attributes!({print_time: DateTime.now})
-      else
-        offer.update_attributes!({hr_status: "Printed", print_time: DateTime.now})
-      end
+  def update_print_status(offer_id)
+    offer = Offer.find(offer_id)
+    if offer[:hr_status] == "Processed"
+      offer.update_attributes!({print_time: DateTime.now})
+    else
+      offer.update_attributes!({hr_status: "Printed", print_time: DateTime.now})
     end
   end
 

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -33,7 +33,7 @@ class OffersController < ApplicationController
     params[:contracts].each do |offer_id|
       offer = Offer.find(offer_id)
       if offer[:send_date]
-        invalid.push(offer_id)
+        invalid.push(offer[:id])
       end
     end
     if invalid.length > 0
@@ -69,7 +69,7 @@ class OffersController < ApplicationController
     params[:contracts].each do |offer_id|
       offer = Offer.find(offer_id)
       if offer[:status] != "Pending"
-        invalid.push(offer_id)
+        invalid.push(offer[:id])
       end
     end
     if invalid.length > 0
@@ -104,7 +104,7 @@ class OffersController < ApplicationController
     params[:contracts].each do |offer_id|
       offer = Offer.find(offer_id)
       if offer[:status] != "Accepted"
-        invalid.push(offer_id)
+        invalid.push(offer[:id])
       end
     end
     if invalid.length > 0

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -29,9 +29,15 @@ class OffersController < ApplicationController
   end
 
   def can_send_contract
-    offer = Offer.find(params[:offer_id])
-    if offer[:send_date]
-      render status: 404, json: {message: "Error: This offer has already been sent."}
+    invalid = []
+    params[:contracts].each do |offer_id|
+      offer = Offer.find(offer_id)
+      if offer[:send_date]
+        invalid.push(offer_id)
+      end
+    end
+    if invalid.length > 0
+      render status: 404, json: {invalid_offers: invalid}
     end
   end
 
@@ -59,9 +65,15 @@ class OffersController < ApplicationController
   end
 
   def can_nag
-    offer = Offer.find(params[:offer_id])
-    if offer[:status] != "Pending"
-      render status: 404, json: {message: "Error: This offer is not in Pending."}
+    invalid = []
+    params[:contracts].each do |offer_id|
+      offer = Offer.find(offer_id)
+      if offer[:status] != "Pending"
+        invalid.push(offer_id)
+      end
+    end
+    if invalid.length > 0
+      render status: 404, json: {invalid_offers: invalid}
     end
   end
 
@@ -88,9 +100,15 @@ class OffersController < ApplicationController
   end
 
   def can_print
-    offer = Offer.find(params[:offer_id])
-    if offer[:status] != "Accepted"
-      render status: 404, json: {message: "Error: This offer has not been accepted."}
+    invalid = []
+    params[:contracts].each do |offer_id|
+      offer = Offer.find(offer_id)
+      if offer[:status] != "Accepted"
+        invalid.push(offer_id)
+      end
+    end
+    if invalid.length > 0
+      render status: 404, json: {invalid_offers: invalid}
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,9 @@ Rails.application.routes.draw do
   # CP routes
   post "offers/can-send-contract" => "offers#can_send_contract"
   post "offers/can-print" => "offers#can_print"
-  post "offers/can_nag" => "offers#can_nag"
+  post "offers/can-nag" => "offers#can_nag"
+  post "offers/can-hr-update" => "offers#can_hr_update"
+  post "offers/can-ddah-update" => "offers#can_ddah_update"
   post "offers/send-contracts" => "offers#send_contracts"
   post "offers/print" => "offers#combine_contracts_print"
   post "offers/nag" => "offers#batch_email_nags"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,9 @@ Rails.application.routes.draw do
   resources :offers do
     post "decision/:status" => "offers#set_status"
     get "pdf" => "offers#get_contract"
+    post "can-send-contract" => "offers#can_send_contract"
+    post "can-print" => "offers#can_print"
+    post "can_nag" => "offers#can_nag"
   end
 
   # shared resources

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,9 +17,6 @@ Rails.application.routes.draw do
   resources :offers do
     post "decision/:status" => "offers#set_status"
     get "pdf" => "offers#get_contract"
-    post "can-send-contract" => "offers#can_send_contract"
-    post "can-print" => "offers#can_print"
-    post "can_nag" => "offers#can_nag"
   end
 
   # shared resources
@@ -34,6 +31,9 @@ Rails.application.routes.draw do
   post "/import/enrollment", to: "import#enrollment"
 
   # CP routes
+  post "offers/can-send-contract" => "offers#can_send_contract"
+  post "offers/can-print" => "offers#can_print"
+  post "offers/can_nag" => "offers#can_nag"
   post "offers/send-contracts" => "offers#send_contracts"
   post "offers/print" => "offers#combine_contracts_print"
   post "offers/nag" => "offers#batch_email_nags"

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -129,28 +129,18 @@ RSpec.describe OffersController, type: :controller do
 
   describe "POST /offers/" do
     context ":offer_id/can-send-contract" do
-      context "when offer_id is valid" do
-        context "when offer has not been sent" do
-          it "returns a status 200" do
-            post :can_send_contract, params: {offer_id: offer[:id]}
-            expect(response.status).to eq(204)
-          end
-        end
-
-        context "when offer has been sent" do
-          it "returns a status 400 and a json message" do
-            post :can_send_contract, params: {offer_id: sent_offer[:id]}
-            expect(response.status).to eq(404)
-            message = {message: "Error: This offer has already been sent."}.to_json
-            expect(response.body).to eq(message)
-          end
+      context "when all offers are valid" do
+        it "returns a status 204" do
+          post :can_send_contract, params: {contracts: [offer[:id]]}
+          expect(response.status).to eq(204)
         end
       end
-      context "when offer_id is invalid" do
-        it "returns a status 400 and a json message" do
-          post :can_send_contract, params: {offer_id: 6000}
+      context "when not all offers are valid" do
+        it "returns a status 400 and a json containing invalid offer_id's" do
+          post :can_send_contract, params: {contracts: [offer[:id], sent_offer[:id]]}
           expect(response.status).to eq(404)
-          expect(response.body).to eq({status: 404}.to_json)
+          json = {invalid_offers: [sent_offer[:id]]}.to_json
+          expect(response.body).to eq(json)
         end
       end
     end
@@ -171,28 +161,18 @@ RSpec.describe OffersController, type: :controller do
     end
 
     context ":offer_id/can-nag" do
-      context "when offer_id is valid" do
-        context "when offer is Pending" do
-          it "returns a status 200" do
-            post :can_nag, params: {offer_id: sent_offer[:id]}
-            expect(response.status).to eq(204)
-          end
-        end
-
-        context "when offer is not Pending" do
-          it "returns a status 400 and a json message" do
-            post :can_nag, params: {offer_id: offer[:id]}
-            expect(response.status).to eq(404)
-            message = {message: "Error: This offer is not in Pending."}.to_json
-            expect(response.body).to eq(message)
-          end
+      context "when all offers are valid" do
+        it "returns a status 204" do
+          post :can_nag, params: {contracts: [sent_offer[:id]]}
+          expect(response.status).to eq(204)
         end
       end
-      context "when offer_id is invalid" do
-        it "returns a status 400 and a json message" do
-          post :can_send_contract, params: {offer_id: 6000}
+      context "when not all offers are valid" do
+        it "returns a status 400 and a json containing invalid offer_id's" do
+          post :can_nag, params: {contracts: [offer[:id], sent_offer[:id]]}
           expect(response.status).to eq(404)
-          expect(response.body).to eq({status: 404}.to_json)
+          json = {invalid_offers: [offer[:id]]}.to_json
+          expect(response.body).to eq(json)
         end
       end
     end
@@ -312,28 +292,18 @@ RSpec.describe OffersController, type: :controller do
 
     end
     context ":offer_id/can-print" do
-      context "when offer_id is valid" do
-        context "when offer is Accepted" do
-          it "returns a status 200" do
-            post :can_print, params: {offer_id: accepted_offer[:id]}
-            expect(response.status).to eq(204)
-          end
-        end
-
-        context "when offer is not Accepted" do
-          it "returns a status 400 and a json message" do
-            post :can_print, params: {offer_id: offer[:id]}
-            expect(response.status).to eq(404)
-            message = {message: "Error: This offer has not been accepted."}.to_json
-            expect(response.body).to eq(message)
-          end
+      context "when all offers are valid" do
+        it "returns a status 204" do
+          post :can_print, params: {contracts: [accepted_offer[:id]]}
+          expect(response.status).to eq(204)
         end
       end
-      context "when offer_id is invalid" do
-        it "returns a status 400 and a json message" do
-          post :can_send_contract, params: {offer_id: 6000}
+      context "when not all offers are valid" do
+        it "returns a status 400 and a json containing invalid offer_id's" do
+          post :can_print, params: {contracts: [offer[:id], accepted_offer[:id]]}
           expect(response.status).to eq(404)
-          expect(response.body).to eq({status: 404}.to_json)
+          json = {invalid_offers: [offer[:id]]}.to_json
+          expect(response.body).to eq(json)
         end
       end
     end

--- a/spec/controllers/offers_controller_spec.rb
+++ b/spec/controllers/offers_controller_spec.rb
@@ -265,7 +265,7 @@ RSpec.describe OffersController, type: :controller do
             it "returns a status 404 with a message" do
               post :set_status, params: {offer_id: accepted_offer[:id], status: "accept"}
               expect(response.status).to eq(404)
-              body = {success: false, message: "You cannot reject this offer. This offer has already been accepted."}
+              body = {success: false, message: "You cannot accept this offer. This offer has already been accepted."}
               expect(response.body).to eq(body.to_json)
             end
           end
@@ -283,7 +283,7 @@ RSpec.describe OffersController, type: :controller do
             it "updates the offer status to Withdrawn" do
               post :set_status, params: {offer_id: accepted_offer[:id], status: "withdraw"}
               expect(response.status).to eq(404)
-              body = {success: false, message: "You cannot reject this offer. This offer has already been accepted."}
+              body = {success: false, message: "You cannot withdraw this offer. This offer has already been accepted."}
               expect(response.body).to eq(body.to_json)
             end
           end
@@ -329,6 +329,41 @@ RSpec.describe OffersController, type: :controller do
           "inline; filename=\"contracts.pdf\"")
         offer.reload
         expect(offer[:hr_status]).to eq(nil)
+      end
+    end
+
+
+    context ":offer_id/can-hr-update" do
+      context "when all offers are valid" do
+        it "returns a status 204" do
+          post :can_hr_update, params: {offers: [accepted_offer[:id]]}
+          expect(response.status).to eq(204)
+        end
+      end
+      context "when not all offers are valid" do
+        it "returns a status 400 and a json containing invalid offer_id's" do
+          post :can_hr_update, params: {offers: [offer[:id], accepted_offer[:id]]}
+          expect(response.status).to eq(404)
+          json = {invalid_offers: [offer[:id]]}.to_json
+          expect(response.body).to eq(json)
+        end
+      end
+    end
+
+    context ":offer_id/can-ddah-update" do
+      context "when all offers are valid" do
+        it "returns a status 204" do
+          post :can_ddah_update, params: {offers: [accepted_offer[:id]]}
+          expect(response.status).to eq(204)
+        end
+      end
+      context "when not all offers are valid" do
+        it "returns a status 400 and a json containing invalid offer_id's" do
+          post :can_ddah_update, params: {offers: [offer[:id], accepted_offer[:id]]}
+          expect(response.status).to eq(404)
+          json = {invalid_offers: [offer[:id]]}.to_json
+          expect(response.body).to eq(json)
+        end
       end
     end
 
@@ -452,7 +487,7 @@ RSpec.describe OffersController, type: :controller do
           it "returns a status 404 with a message" do
             post :set_status_mangled, params: {mangled: accepted_offer[:link], status: "accept"}
             expect(response.status).to eq(404)
-            body = {success: false, message: "You cannot reject this offer. This offer has already been accepted."}
+            body = {success: false, message: "You cannot accept this offer. This offer has already been accepted."}
             expect(response.body).to eq(body.to_json)
           end
         end


### PR DESCRIPTION
- new routes:
  - (a) `POST /offers/can-send-contract` 
  - (b) `POST /offers/can-nag`
  - (c) `POST /offers/can-print`
  - (d) `POST/offers/can-hr-update`
  - (e) `POST /offers/can-ddah-update`
- on success: return status code 204
- on failure: return status 404 with json `{"invalid_offers": [offer_id, ...]}`
- a, b, c expects a `{"contracts": [offer_id, ...]}`
- d, e expects a  `{"offers": [offer_id, ...]}`
- made rspec for new routes

Assumptions:
- all `offer_id` in the array `contracts` are valid `Offer` checked by checking its respective checks
- old routes with assumptions:
  - `POST /offers/send-contracts` -- a
  - `POST /offers/nag` -- b
  - `POST /offers/print` -- c
