### PR TITLE
Add check to offer json import

### DIFF
--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -3,7 +3,12 @@ class ImportController < ApplicationController
 
   def import_offers
     importer = OfferImporter.new
-    importer.import_json(params[:chass_offers])
+    status = importer.import_json(params[:chass_offers])
+    if status[:imported]
+      render json: {message: status[:message], errors: status[:errors]}
+    else
+      render status: 404, json: {message: status[:message], errors: status[:errors]}
+    end
   end
 
   def import_locked_assignments

--- a/app/controllers/import_controller.rb
+++ b/app/controllers/import_controller.rb
@@ -14,6 +14,7 @@ class ImportController < ApplicationController
   def import_locked_assignments
     importer = OfferImporter.new
     importer.import_assignments()
+    render json: {errors: false, message: ["Importing locked assignments as offers was successful."]}}
   end
 
   def chass

--- a/app/services/offer_importer.rb
+++ b/app/services/offer_importer.rb
@@ -19,7 +19,7 @@ class OfferImporter
     elsif exceptions.length > 0
       return {imported: true, errors: true, message: exceptions}
     else
-      return {imported: true, errors: false, message: ["Offers import success."]}
+      return {imported: true, errors: false, message: ["Offers import was successful."]}
     end
   end
 


### PR DESCRIPTION
- **Note:** Don't merge unless front-end for this is done
- update response of offers import for both `import_json` and `import_locked_assignments`
- all possible responses:
  - status 404, `{errors: true, message: [array of strings]}` --> doesn't require fetchall()
  - status 200, `{errors: true, message: [array of strings]}` --> require fetchall()
  - status 200, `{errors: false, message: [array of strings]}` (message length = 1) --> require fetchall()