### PR TITLE
do not copy id field when deep-copying template allocations

### DIFF
--- a/app/javascript/cp/appState.js
+++ b/app/javascript/cp/appState.js
@@ -1128,7 +1128,6 @@ class AppState {
             allocations: ddah
                 .get('allocations')
                 .map(allocation => ({
-                    id: allocation.get('id'),
                     num_unit: allocation.get('units'),
                     unit_name: allocation.get('type'),
                     minutes: allocation.get('time'),


### PR DESCRIPTION
when applying a template should not set the id parameter of the allocations.
See issue @94