### PR TITLE
Create UI for adding/editing instructors in Tapp

### DIFF
--- a/app/assets/stylesheets/tapp.css
+++ b/app/assets/stylesheets/tapp.css
@@ -180,6 +180,23 @@ footer div p {
     overflow: auto;
 }
 
+.instructor-modal-opener{
+  color: #000;
+  margin-left: 10px;
+}
+
+.clickable{
+  cursor: pointer;
+}
+
+.clickable:hover{
+  opacity: .75;
+}
+
+.clickable:active{
+  opacity: .9;
+}
+
 /* for ApplicantTable in Assigned/Unassigned view */
 #unassigned-grid .table-container,
 #assigned-grid .table-container {

--- a/app/assets/stylesheets/tapp.css
+++ b/app/assets/stylesheets/tapp.css
@@ -561,3 +561,8 @@ footer div p {
   text-decoration: none;
   color: #555;
 }
+
+/* ---- instructor_form ----- */
+#instructor-modal-alert{
+  opacity: 0;
+}

--- a/app/assets/stylesheets/tapp.css
+++ b/app/assets/stylesheets/tapp.css
@@ -185,6 +185,19 @@ footer div p {
   margin-left: 10px;
 }
 
+#instructor-modal-utorid-row i{
+  font-size: 40px;
+  color: #aaa;
+  margin-right: 10px;
+  float: right;
+}
+#instructor-modal-utorid-row i:hover{
+  color: #666;
+}
+#instructor-modal-utorid-row i:active{
+  color: #333;
+}
+
 .clickable{
   cursor: pointer;
 }

--- a/app/assets/stylesheets/tapp.css
+++ b/app/assets/stylesheets/tapp.css
@@ -561,8 +561,3 @@ footer div p {
   text-decoration: none;
   color: #555;
 }
-
-/* ---- instructor_form ----- */
-#instructor-modal-alert{
-  opacity: 0;
-}

--- a/app/controllers/instructors_controller.rb
+++ b/app/controllers/instructors_controller.rb
@@ -13,6 +13,49 @@ class InstructorsController < ApplicationController
     render json: instructor.to_json
   end
 
+  def create
+    if params[:utorid]
+      if params[:name] || params[:email]
+        instructor = Instructor.find_by(utorid: params[:utorid])
+        if !instructor
+          Instructor.create(
+            utorid: params[:utorid],
+            name: params[:name],
+            email: params[:email],
+          )
+          render status: 200, json: {message: "Instructor #{params[:name]} has been created.'"}
+        else
+          render status: 404, json: {message: "This instructor already exists.", id: instructor[:id]}
+        end
+      else
+        render status: 404, json: {message: "Missing either name or email."}
+      end
+    else
+      render status: 404, json: {message: "No utorid given."}
+    end
+  end
+
+  def update
+    if params[:id]
+      instructor = Instructor.find(params[:id])
+      if instructor
+        if params[:name] || params[:email]
+          instructor.update_attributes!(
+            name: params[:name],
+            email: params[:email],
+          )
+          render status: 200, json: {message: "Instructor #{params[:name]}'s data has been updated.'"}
+        else
+          render status: 404, json: {message: "Missing either name or email."}
+        end
+      else
+        render status: 404, json: {message: "No instructor with id #{params[:id]} exists in the system."}
+      end
+    else
+      render status: 404, json: {message: "No id given."}
+    end
+  end
+
   def show_by_utorid
     instructor = Instructor.find_by(utorid: params[:utorid])
     render json: instructor.to_json

--- a/app/controllers/instructors_controller.rb
+++ b/app/controllers/instructors_controller.rb
@@ -25,7 +25,7 @@ class InstructorsController < ApplicationController
           )
           render status: 200, json: {message: "Instructor #{params[:name]} has been created.'"}
         else
-          render status: 404, json: {message: "This instructor already exists.", id: instructor[:id]}
+          render status: 404, json: {message: "This instructor already exists."}
         end
       else
         render status: 404, json: {message: "Missing either name or email."}

--- a/app/controllers/instructors_controller.rb
+++ b/app/controllers/instructors_controller.rb
@@ -56,6 +56,14 @@ class InstructorsController < ApplicationController
     end
   end
 
+  def destroy
+    instructor = Instructor.find(params[:id])
+    if instructor
+      instructor.destroy!
+      render status: 200, json: {message: "Instructor #{params[:id]} has been deleted."}
+    end
+  end
+
   def show_by_utorid
     instructor = Instructor.find_by(utorid: params[:utorid])
     render json: instructor.to_json

--- a/app/controllers/instructors_controller.rb
+++ b/app/controllers/instructors_controller.rb
@@ -15,7 +15,7 @@ class InstructorsController < ApplicationController
 
   def create
     if params[:utorid]
-      if params[:name] || params[:email]
+      if params[:name] && params[:email]
         instructor = Instructor.find_by(utorid: params[:utorid])
         if !instructor
           Instructor.create(
@@ -36,31 +36,29 @@ class InstructorsController < ApplicationController
   end
 
   def update
-    if params[:id]
-      instructor = Instructor.find(params[:id])
-      if instructor
-        if params[:name] || params[:email]
-          instructor.update_attributes!(
-            name: params[:name],
-            email: params[:email],
-          )
-          render status: 200, json: {message: "Instructor #{params[:name]}'s data has been updated.'"}
-        else
-          render status: 404, json: {message: "Missing either name or email."}
-        end
+    instructor = Instructor.find_by(id: params[:id])
+    if instructor
+      if params[:name] && params[:email]
+        instructor.update_attributes!(
+          name: params[:name],
+          email: params[:email],
+        )
+        render status: 200, json: {message: "Instructor #{params[:name]}'s data has been updated.'"}
       else
-        render status: 404, json: {message: "No instructor with id #{params[:id]} exists in the system."}
+        render status: 404, json: {message: "Missing either name or email."}
       end
     else
-      render status: 404, json: {message: "No id given."}
+      render status: 404, json: {message: "No instructor with id #{params[:id]} exists in the system."}
     end
   end
 
   def destroy
-    instructor = Instructor.find(params[:id])
+    instructor = Instructor.find_by(id: params[:id])
     if instructor
       instructor.destroy!
       render status: 200, json: {message: "Instructor #{params[:id]} has been deleted."}
+    else
+      render status: 404, json: {message: "No instructor with id #{params[:id]} exists in the system."}
     end
   end
 

--- a/app/javascript/cp/fetch.js
+++ b/app/javascript/cp/fetch.js
@@ -45,8 +45,8 @@ const getOffers = user => getResource(
 const downloadFile = (route) => fetchProc.downloadFile(route, appState);
 const importData = (route, data, fetch) => fetchProc.importData(route, data, fetch, appState);
 const postData = (route, data, fetch, okay = null, error = null) => fetchProc.postData(route, data, fetch, appState, okay, error);
-const putData = (route, data, fetch) => fetchProc.putData(route, data, fetch, appState);
-const deleteData = (route, fetch) => fetchProc.deleteData(route, fetch, appState);
+const putData = (route, data, fetch, okay = null, error = null) => fetchProc.putData(route, data, fetch, appState, okay, error);
+const deleteData = (route, fetch, okay = null, error = null) => fetchProc.deleteData(route, fetch, appState, okay, error);
 
 const batchOfferAction = (canRoute, actionRoute, data, msg, fetch, extra = null, put =false) =>
   fetchProc.batchOfferAction(canRoute, actionRoute, data, msg, fetch, extra, put, appState);

--- a/app/javascript/fetchProc.js
+++ b/app/javascript/fetchProc.js
@@ -227,7 +227,10 @@ export const onFetchAssignmentsSuccess = (resp) => {
 export const onFetchInstructorsSuccess = (resp) => {
     let instructors = {};
     resp.forEach(instr => {
-        instructors[instr.id] = instr.name;
+        instructors[instr.id] = {
+          name: instr.name,
+          utorid: instr.utorid,
+        };
     });
     return instructors;
 }

--- a/app/javascript/tapp/appState.js
+++ b/app/javascript/tapp/appState.js
@@ -60,6 +60,9 @@ const initialState = {
         tempAssignments: [],
     },
 
+    // instructor Modal
+    instructorModal: null,
+
     /** DB data **/
 
     applicants: { fetching: 0, list: null },
@@ -715,6 +718,40 @@ class AppState {
         // Note: toString() is a hack because our components think that course IDs are numbers but Immutable
         // thinks they are strings
         return this.getApplicantsList().get(applicant.toString());
+    }
+
+    updateInstructor(instructor){
+        fetch.updateInstructor(instructor);
+    }
+
+    createInstructor(instructor){
+        fetch.createInstructor(instructor);
+    }
+
+    instructorModalOpen(){
+      return this.get("instructorModal");
+    }
+
+    showInstructorModal(){
+      this.set("instructorModal", {
+        selectedTab: 1,
+        instructor: {
+          id: null,
+          utorid: null,
+          name: null,
+          email: null,
+        },
+      });
+    }
+
+    switchInstructorModalTab(tab){
+      if (this.instructorModalOpen()){
+        this.set("instructorModal.selectedTab", tab);
+      }
+    }
+
+    hideInstructorModal(){
+      this.set("instructorModal", null);
     }
 
     getApplicantsInSelectedRound() {

--- a/app/javascript/tapp/appState.js
+++ b/app/javascript/tapp/appState.js
@@ -794,6 +794,17 @@ class AppState {
       });
     }
 
+    deleteInstructor(){
+      let id = this.getInstructorDataFromModal('id', true);
+      if(id=='')
+        this.alert('No instructor selected.');
+      else{
+        let response = confirm("Are you sure you want to delete this instructor?");
+        if(response)
+            fetch.deleteInstructor(parseInt(id));
+      }
+    }
+
     createInstructor(){
       this.validateInstructorModalForm((instructor, action2)=>{
         if(!this.validInstructorUtorid(instructor.utorid))

--- a/app/javascript/tapp/appState.js
+++ b/app/javascript/tapp/appState.js
@@ -720,12 +720,67 @@ class AppState {
         return this.getApplicantsList().get(applicant.toString());
     }
 
-    updateInstructor(instructor){
-        fetch.updateInstructor(instructor);
+    getInstructorDataFromModal(key = null){
+      if (key){
+          return this.get('instructorModal.instructor.'+key);
+      }
+      else {
+          let id = this.getInstructorDataFromModal('id');
+          if(id){
+            return {
+              id: id,
+              utorid: this.getInstructorDataFromModal('utorid'),
+              name: this.getInstructorDataFromModal('name'),
+              email: this.getInstructorDataFromModal('email'),
+            };
+          }
+          else{
+            return {
+              utorid: this.getInstructorDataFromModal('utorid'),
+              name: this.getInstructorDataFromModal('name'),
+              email: this.getInstructorDataFromModal('email'),
+            };
+          }
+      }
     }
 
-    createInstructor(instructor){
-        fetch.createInstructor(instructor);
+    setInstructorDataFromModal(key, val){
+        this.set('instructorModal.instructor.'+key, val);
+    }
+
+    getSelectedTabFromModal(){
+      return this.get('instructorModal.selectedTab');
+    }
+
+    setSelectedTabFromModal(tab){
+        this.set("instructorModal.selectedTab", tab);
+    }
+
+    containsEmptyInstructorField(instructor){
+      let keys = Object.keys(instructor);
+      keys.forEach(key=>{
+        if(instructor[key].length == 0)
+          return true;
+      });
+      return false;
+    }
+
+    updateInstructor(){
+        if(this.instructorModalOpen()){
+          let instructor = this.getInstructorDataFromModal();
+          if(!this.containsEmptyInstructorField(instructor)){
+            fetch.updateInstructor(instructor);
+          }
+        }
+    }
+
+    createInstructor(){
+      if(this.instructorModalOpen()){
+        let instructor = this.getInstructorDataFromModal();
+        if(!this.containsEmptyInstructorField(instructor)){
+          fetch.createInstructor(instructor);
+        }
+      }
     }
 
     instructorModalOpen(){
@@ -733,21 +788,15 @@ class AppState {
     }
 
     showInstructorModal(){
-      this.set("instructorModal", {
-        selectedTab: 1,
+      this.set("instructorModal", fromJS({
+        selectedTab: 'create',
         instructor: {
           id: null,
           utorid: null,
           name: null,
           email: null,
         },
-      });
-    }
-
-    switchInstructorModalTab(tab){
-      if (this.instructorModalOpen()){
-        this.set("instructorModal.selectedTab", tab);
-      }
+      }));
     }
 
     hideInstructorModal(){

--- a/app/javascript/tapp/appState.js
+++ b/app/javascript/tapp/appState.js
@@ -735,18 +735,19 @@ class AppState {
         return this.getApplicantsList().get(applicant.toString());
     }
 
-    getInstructorDataFromModal(key = null){
+    getInstructorDataFromModal(key = null, trim = false){
       if (key){
-          return this.get('instructorModal.instructor.'+key)?
-            this.get('instructorModal.instructor.'+key).trim(): '';
+        let result = this.get('instructorModal.instructor.'+key)?
+          this.get('instructorModal.instructor.'+key): '';
+        return trim?result.trim():result;
       }
       else {
-        let id = this.getInstructorDataFromModal('id');
+        let id = this.getInstructorDataFromModal('id', true);
         return {
             id: (id==''||!id)? null: parseInt(id),
-            utorid: this.getInstructorDataFromModal('utorid'),
-            name: this.getInstructorDataFromModal('name'),
-            email: this.getInstructorDataFromModal('email'),
+            utorid: this.getInstructorDataFromModal('utorid', true),
+            name: this.getInstructorDataFromModal('name', true),
+            email: this.getInstructorDataFromModal('email', true),
           };
       }
     }

--- a/app/javascript/tapp/components/applicantModal.js
+++ b/app/javascript/tapp/components/applicantModal.js
@@ -12,9 +12,9 @@ class ApplicantModal extends React.Component {
                     <Modal.Title>
                         {applicant.lastName},&nbsp;{applicant.firstName}
                         <span className="text-muted" style={{ float: 'right' }}>
-                            <i className="fa fa-external-link" style={{ fontSize: '16px' }} />&ensp;
+                            <i className="fa fa-external-link clickable" style={{ fontSize: '16px' }} />&ensp;
                             <i
-                                className="fa fa-times"
+                                className="fa fa-times clickable"
                                 style={{ fontSize: '18px' }}
                                 onClick={() => this.props.unselectApplicant()}
                             />

--- a/app/javascript/tapp/components/courseForm.js
+++ b/app/javascript/tapp/components/courseForm.js
@@ -171,7 +171,11 @@ class CourseForm extends React.Component {
 
                             <td className="col-7">
                                 <p>
-                                    <b>Instructors: </b>
+                                    <b>Instructors
+                                     <i className="fa fa-pencil instructor-modal-opener clickable"
+                                      title="Open Instructor Editor"
+                                      onClick={()=> this.props.showInstructorModal()}></i>
+                                    </b>
                                 </p>
                                 <InstructorForm
                                     courseId={this.props.courseId}

--- a/app/javascript/tapp/components/courses.js
+++ b/app/javascript/tapp/components/courses.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import { Grid, Panel, ListGroup } from 'react-bootstrap';
 import { CourseList } from './courseList.js';
 import { CourseForm } from './courseForm.js';
+import { InstructorModal } from './instructorModal.js';
 
 class Courses extends React.Component {
     selectThisTab() {
@@ -34,7 +35,6 @@ class Courses extends React.Component {
         return (
             <Grid fluid id="courses-grid">
                 <CourseList courses={courses}  {...this.props}/>
-
                 <Panel id="course-form">
                     <ListGroup fill>
                         {courses.map(([key, course]) =>
@@ -42,6 +42,7 @@ class Courses extends React.Component {
                         )}
                     </ListGroup>
                 </Panel>
+                <InstructorModal {...this.props}/>
             </Grid>
         );
     }

--- a/app/javascript/tapp/components/instructorModal.js
+++ b/app/javascript/tapp/components/instructorModal.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Modal, Row, Col, Nav, NavItem, Tab, Button } from 'react-bootstrap';
+import { Applicant } from './applicant.js';
+
+class InstructorModal extends React.Component {
+    render() {
+        let instructors = this.props.getInstructorsList();
+        if(this.props.instructorModalOpen()){
+          let instructor = null,
+              selectedTab = 1;
+          return (
+              <Modal id="instructor-modal" show={true} onHide={() => this.props.hideInstructorModal()}>
+                  <Modal.Header>
+                      <Modal.Title>
+                          Instructor Editor
+                          <span className="text-muted" style={{ float: 'right' }}>
+                              <i className="fa fa-times clickable"
+                                  style={{ fontSize: '18px' }}
+                                  onClick={() => this.props.hideInstructorModal()}
+                              />
+                          </span>
+                      </Modal.Title>
+                  </Modal.Header>
+                  <Modal.Body>
+                      <Tab.Container id="tabs-with-dropdown" defaultActiveKey="create">
+                          <Row className="clearfix">
+                          <Col sm={12}>
+                            <Nav bsStyle="tabs">
+                              <NavItem eventKey="create">Create Instructor</NavItem>
+                              <NavItem eventKey="edit">Edit Instructor</NavItem>
+                            </Nav>
+                          </Col>
+                          <Col sm={12}>
+                            <Tab.Content animation>
+                              <Tab.Pane eventKey="create">
+                              Tab 1 content
+                              </Tab.Pane>
+                              <Tab.Pane eventKey="edit">
+                              Tab 2 content
+                              </Tab.Pane>
+                            </Tab.Content>
+                          </Col>
+                          </Row>
+                      </Tab.Container>
+                  </Modal.Body>
+                  <Modal.Footer>
+                      <Button onClick={() => this.props.hideInstructorModal()}>Close</Button>
+                      <Button bsStyle="primary"
+                      onClick={()=>(selectedTab==1)?
+                          this.props.createInstructor(instructor): this.props.updateInstructor(instructor)}>
+                        {selectedTab==1? 'Submit': 'Save Changes'}
+                        </Button>
+                  </Modal.Footer>
+              </Modal>
+          );
+        }
+        return null;
+    }
+}
+
+export { InstructorModal };

--- a/app/javascript/tapp/components/instructorModal.js
+++ b/app/javascript/tapp/components/instructorModal.js
@@ -1,15 +1,20 @@
 import React from 'react';
-import { Modal, Row, Col, Nav, NavItem, Tab, Button } from 'react-bootstrap';
+import { Modal, Form, FormGroup, FormControl,DropdownButton, MenuItem, Row, Col, Nav, NavItem, Tab, Button } from 'react-bootstrap';
 import { Applicant } from './applicant.js';
 
 class InstructorModal extends React.Component {
     render() {
-        let instructors = this.props.getInstructorsList();
-        if(this.props.instructorModalOpen()){
-          let instructor = null,
-              selectedTab = 1;
+        let modalData = this.props.instructorModalOpen();
+        if(modalData){
+          let id = this.props.getInstructorDataFromModal('id'),
+              utorid = this.props.getInstructorDataFromModal('utorid'),
+              name = this.props.getInstructorDataFromModal('name'),
+              email = this.props.getInstructorDataFromModal('email'),
+              instructors = this.props.getInstructorsList(),
+              selectedTab = this.props.getSelectedTabFromModal();
           return (
               <Modal id="instructor-modal" show={true} onHide={() => this.props.hideInstructorModal()}>
+                <Form horizontal>
                   <Modal.Header>
                       <Modal.Title>
                           Instructor Editor
@@ -21,23 +26,24 @@ class InstructorModal extends React.Component {
                           </span>
                       </Modal.Title>
                   </Modal.Header>
-                  <Modal.Body>
-                      <Tab.Container id="tabs-with-dropdown" defaultActiveKey="create">
+                  <Modal.Body style={{paddingTop: '0'}}>
+                      <Tab.Container id="tabs-with-dropdown" defaultActiveKey={selectedTab}
+                        onSelect={key=>this.props.setSelectedTabFromModal(key)}>
                           <Row className="clearfix">
                           <Col sm={12}>
-                            <Nav bsStyle="tabs">
+                            <Nav bsStyle="pills">
                               <NavItem eventKey="create">Create Instructor</NavItem>
                               <NavItem eventKey="edit">Edit Instructor</NavItem>
                             </Nav>
                           </Col>
                           <Col sm={12}>
-                            <Tab.Content animation>
-                              <Tab.Pane eventKey="create">
-                              Tab 1 content
-                              </Tab.Pane>
-                              <Tab.Pane eventKey="edit">
-                              Tab 2 content
-                              </Tab.Pane>
+                            <Tab.Content animation style={{margin: '50px 0 20px 20px'}}>
+                              <CreateInstructor {...this.props} id={id}
+                                utorid={utorid} name={name} email={email}
+                                instructors={instructors}/>
+                              <EditInstructor {...this.props} id={id}
+                                utorid={utorid} name={name} email={email}
+                                instructors={instructors}/>
                             </Tab.Content>
                           </Col>
                           </Row>
@@ -46,16 +52,88 @@ class InstructorModal extends React.Component {
                   <Modal.Footer>
                       <Button onClick={() => this.props.hideInstructorModal()}>Close</Button>
                       <Button bsStyle="primary"
-                      onClick={()=>(selectedTab==1)?
-                          this.props.createInstructor(instructor): this.props.updateInstructor(instructor)}>
-                        {selectedTab==1? 'Submit': 'Save Changes'}
+                      onClick={()=>(selectedTab=='create')?
+                          this.props.createInstructor(): this.props.updateInstructor()}>
+                        {selectedTab=='create'? 'Submit': 'Save Changes'}
                         </Button>
                   </Modal.Footer>
+                </Form>
               </Modal>
           );
         }
         return null;
     }
 }
+
+const CreateInstructor = props =>(
+  <Tab.Pane eventKey="create">
+      <FormFormat cid='instructor-utorid' type='text'
+        label='Utorid'
+        placeholder='Utorid'
+        value={props.utorid}
+        update={event=>props.setInstructorDataFromModal('utorid', event.target.value)}
+        {...props}/>
+      <InstructorForm
+        name={props.name}
+        email={props.email}
+        {...props}/>
+  </Tab.Pane>
+);
+
+const EditInstructor = props =>(
+  <Tab.Pane eventKey="edit">
+    <FormFormat cid='instructor-utorid-dropdown' type='dropdown'
+      label='Instructor'
+      placeholder={props.id?props.instructors[props.id]:'Choose a Utorid'}
+      value={props.name}
+      update={key=>props.setInstructorDataFromModal('id', key)}
+      body={Object.keys(props.instructors).map(key=>
+        <MenuItem key={key} eventKey={key}>{props.instructors[key]}</MenuItem>
+      )}
+      {...props}/>
+    <InstructorForm
+      name={props.name}
+      email={props.email}
+      {...props}/>
+  </Tab.Pane>
+);
+
+const InstructorForm = props =>(
+  <div>
+    <FormFormat cid='instructor-name' type='text'
+      label='Name'
+      placeholder='Full Name'
+      value={props.name}
+      update={event=>props.setInstructorDataFromModal('name', event.target.value)}
+      {...props}/>
+    <FormFormat cid='instructor-email' type='email'
+      label='Email'
+      placeholder='Email'
+      value={props.email}
+      update={event=>props.setInstructorDataFromModal('email', event.target.value)}
+      {...props}/>
+  </div>
+);
+
+const FormFormat = props =>(
+  <FormGroup controlId={props.cid}>
+    <Col sm={3}>
+      {props.label}
+    </Col>
+    <Col sm={9}>
+      {(props.type=='dropdown')?
+      <DropdownButton key='1' id={props.cid}
+        bsStyle='default'
+        title={props.placeholder}
+        onSelect={props.update}>
+        {props.body}
+      </DropdownButton>:
+      <FormControl type={props.type}
+        placeholder={props.placeholder}
+        onBlur={props.update}
+        defaultValue={props.value?props.value:''}/>}
+    </Col>
+  </FormGroup>
+);
 
 export { InstructorModal };

--- a/app/javascript/tapp/components/instructorModal.js
+++ b/app/javascript/tapp/components/instructorModal.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Form, FormGroup, FormControl,DropdownButton, MenuItem, Row, Col, Nav, NavItem, Tab, Button } from 'react-bootstrap';
+import { Modal, Form, FormGroup, Alert, FormControl,DropdownButton, MenuItem, Row, Col, Nav, NavItem, Tab, Button } from 'react-bootstrap';
 import { Applicant } from './applicant.js';
 
 class InstructorModal extends React.Component {
@@ -10,8 +10,9 @@ class InstructorModal extends React.Component {
               utorid = this.props.getInstructorDataFromModal('utorid'),
               name = this.props.getInstructorDataFromModal('name'),
               email = this.props.getInstructorDataFromModal('email'),
-              instructors = this.props.getInstructorsList(),
+              instructors = this.props.getInstructorsList(true),
               selectedTab = this.props.getSelectedTabFromModal();
+
           return (
               <Modal id="instructor-modal" show={true} onHide={() => this.props.hideInstructorModal()}>
                 <Form horizontal>
@@ -35,9 +36,10 @@ class InstructorModal extends React.Component {
                               <NavItem eventKey="create">Create Instructor</NavItem>
                               <NavItem eventKey="edit">Edit Instructor</NavItem>
                             </Nav>
+                            <Alert id='instructor-modal-alert' bsStyle="danger">text</Alert>
                           </Col>
                           <Col sm={12}>
-                            <Tab.Content animation style={{margin: '50px 0 20px 20px'}}>
+                            <Tab.Content animation style={{margin: '0px 0 20px 20px'}}>
                               <CreateInstructor {...this.props} id={id}
                                 utorid={utorid} name={name} email={email}
                                 instructors={instructors}/>
@@ -73,10 +75,7 @@ const CreateInstructor = props =>(
         value={props.utorid}
         update={event=>props.setInstructorDataFromModal('utorid', event.target.value)}
         {...props}/>
-      <InstructorForm
-        name={props.name}
-        email={props.email}
-        {...props}/>
+      <InstructorForm name={props.name} email={props.email} {...props}/>
   </Tab.Pane>
 );
 
@@ -84,17 +83,16 @@ const EditInstructor = props =>(
   <Tab.Pane eventKey="edit">
     <FormFormat cid='instructor-utorid-dropdown' type='dropdown'
       label='Instructor'
-      placeholder={props.id?props.instructors[props.id]:'Choose a Utorid'}
+      placeholder={props.id?props.instructors[props.id]['utorid']:'Choose a Utorid'}
       value={props.name}
       update={key=>props.setInstructorDataFromModal('id', key)}
       body={Object.keys(props.instructors).map(key=>
-        <MenuItem key={key} eventKey={key}>{props.instructors[key]}</MenuItem>
+            <MenuItem key={key} eventKey={key}>
+              {props.instructors[key]['utorid']}
+            </MenuItem>
       )}
       {...props}/>
-    <InstructorForm
-      name={props.name}
-      email={props.email}
-      {...props}/>
+    <InstructorForm name={props.name} email={props.email} {...props}/>
   </Tab.Pane>
 );
 

--- a/app/javascript/tapp/components/instructorModal.js
+++ b/app/javascript/tapp/components/instructorModal.js
@@ -114,12 +114,15 @@ const FormFormat = props =>(
     </Col>
     <Col sm={9}>
       {(props.type=='dropdown')?
+      <div id='instructor-modal-utorid-row'>
       <DropdownButton key='1' id={props.cid}
         bsStyle='default'
         title={props.placeholder}
         onSelect={props.update}>
         {props.body}
-      </DropdownButton>:
+      </DropdownButton>
+      <i className='fa fa-trash' onClick={()=>props.deleteInstructor()}></i>
+      </div>:
       <FormControl type={props.type}
         placeholder={props.placeholder}
         onChange={props.update}

--- a/app/javascript/tapp/components/instructorModal.js
+++ b/app/javascript/tapp/components/instructorModal.js
@@ -7,9 +7,6 @@ class InstructorModal extends React.Component {
         let modalData = this.props.instructorModalOpen();
         if(modalData){
           let id = this.props.getInstructorDataFromModal('id'),
-              utorid = this.props.getInstructorDataFromModal('utorid'),
-              name = this.props.getInstructorDataFromModal('name'),
-              email = this.props.getInstructorDataFromModal('email'),
               instructors = this.props.getInstructorsList(true),
               selectedTab = this.props.getSelectedTabFromModal();
 
@@ -36,16 +33,14 @@ class InstructorModal extends React.Component {
                               <NavItem eventKey="create">Create Instructor</NavItem>
                               <NavItem eventKey="edit">Edit Instructor</NavItem>
                             </Nav>
-                            <Alert id='instructor-modal-alert' bsStyle="danger">text</Alert>
+                            <Alert bsStyle="danger" style={{opacity: this.props.getInstructorModalAlert()?'1':'0'}}>
+                              <b>Error: </b>{this.props.getInstructorModalAlert()}
+                            </Alert>
                           </Col>
                           <Col sm={12}>
                             <Tab.Content animation style={{margin: '0px 0 20px 20px'}}>
-                              <CreateInstructor {...this.props} id={id}
-                                utorid={utorid} name={name} email={email}
-                                instructors={instructors}/>
-                              <EditInstructor {...this.props} id={id}
-                                utorid={utorid} name={name} email={email}
-                                instructors={instructors}/>
+                              <CreateInstructor {...this.props} instructors={instructors}/>
+                              <EditInstructor {...this.props} id={id} instructors={instructors}/>
                             </Tab.Content>
                           </Col>
                           </Row>
@@ -72,10 +67,10 @@ const CreateInstructor = props =>(
       <FormFormat cid='instructor-utorid' type='text'
         label='Utorid'
         placeholder='Utorid'
-        value={props.utorid}
+        value={props.getInstructorDataFromModal('utorid')}
         update={event=>props.setInstructorDataFromModal('utorid', event.target.value)}
         {...props}/>
-      <InstructorForm name={props.name} email={props.email} {...props}/>
+      <InstructorForm {...props}/>
   </Tab.Pane>
 );
 
@@ -84,7 +79,6 @@ const EditInstructor = props =>(
     <FormFormat cid='instructor-utorid-dropdown' type='dropdown'
       label='Instructor'
       placeholder={props.id?props.instructors[props.id]['utorid']:'Choose a Utorid'}
-      value={props.name}
       update={key=>props.setInstructorDataFromModal('id', key)}
       body={Object.keys(props.instructors).map(key=>
             <MenuItem key={key} eventKey={key}>
@@ -92,7 +86,7 @@ const EditInstructor = props =>(
             </MenuItem>
       )}
       {...props}/>
-    <InstructorForm name={props.name} email={props.email} {...props}/>
+    <InstructorForm {...props}/>
   </Tab.Pane>
 );
 
@@ -101,13 +95,13 @@ const InstructorForm = props =>(
     <FormFormat cid='instructor-name' type='text'
       label='Name'
       placeholder='Full Name'
-      value={props.name}
+      value={props.getInstructorDataFromModal('name')}
       update={event=>props.setInstructorDataFromModal('name', event.target.value)}
       {...props}/>
     <FormFormat cid='instructor-email' type='email'
       label='Email'
       placeholder='Email'
-      value={props.email}
+      value={props.getInstructorDataFromModal('email')}
       update={event=>props.setInstructorDataFromModal('email', event.target.value)}
       {...props}/>
   </div>
@@ -128,8 +122,8 @@ const FormFormat = props =>(
       </DropdownButton>:
       <FormControl type={props.type}
         placeholder={props.placeholder}
-        onBlur={props.update}
-        defaultValue={props.value?props.value:''}/>}
+        onChange={props.update}
+        value={props.value}/>}
     </Col>
   </FormGroup>
 );

--- a/app/javascript/tapp/fetch.js
+++ b/app/javascript/tapp/fetch.js
@@ -172,7 +172,7 @@ export const exportOffers = (round, session) => {
 export const updateInstructor = (instructor) => {
     let fetch = true;
     putData('/instructors/'+instructor.id, instructor, resp=>{
-      getInstructors();
+      if(fetch) getInstructors();
     },
     resp=>{
       alert(resp.message);
@@ -184,11 +184,25 @@ export const updateInstructor = (instructor) => {
     });
 }
 
+export const deleteInstructor = (id) => {
+  let fetch = true;
+  deleteData('/instructors/'+id, ()=>{
+    if(fetch) getInstructors();
+  },
+  resp=>{
+    alert(resp.message);
+    appState.hideInstructorModal();
+  },
+  resp=>{
+    appState.alert(resp.message);
+    fetch = false;
+  });
+}
+
 export const createInstructor = (instructor) => {
     let fetch = true;
     postData('/instructors', instructor, ()=>{
-      if(fetch)
-        getInstructors();
+      if(fetch) getInstructors();
     },
     resp=>{
       alert(resp.message);

--- a/app/javascript/tapp/fetch.js
+++ b/app/javascript/tapp/fetch.js
@@ -169,6 +169,45 @@ export const exportOffers = (round, session) => {
     .then(() => getAssignments());
 }
 
+export const updateInstructor = (instructor) => {
+    let fetch = true;
+    putData('/instructors', instructor, ()=>{
+      getInstructors();
+    },
+    resp=>{
+      alert(resp.message);
+      appState.hideInstructorModal();
+    },
+    resp=>{
+        appState.alert("<b>Error</b>: "+resp.message);
+        fetch = false;
+    });
+}
+
+export const createInstructor = (instructor) => {
+    let fetch = true;
+    postData('/instructors', instructor, ()=>{
+      if(fetch)
+        getInstructors();
+    },
+    resp=>{
+      alert(resp.message);
+      appState.hideInstructorModal();
+    },
+    resp=>{
+      fetch = false;
+      if(resp.id){
+        let choice = confirm("An instructor with the same utorid already exists. Do you want update the information for that instructor?");
+        if(choice){
+          appState.switchInstructorModalTab("update");
+        }
+      }
+      else{
+        appState.alert("<b>Error</b>: "+resp.message);
+      }
+    })
+}
+
 // get current user role and username
 // if we are in development, set the current user name to a special value
 export const fetchAuth = () => {

--- a/app/javascript/tapp/fetch.js
+++ b/app/javascript/tapp/fetch.js
@@ -36,8 +36,8 @@ const getAssignments = () => getResource('/assignments',
 export const downloadFile = (route) => fetchProc.downloadFile(route, appState);
 const importData = (route, data, fetch) => fetchProc.importData(route, data, fetch, appState);
 const postData = (route, data, fetch, okay = null, error = null) => fetchProc.postData(route, data, fetch, appState, okay, error);
-const putData = (route, data, fetch) => fetchProc.putData(route, data, fetch, appState);
-const deleteData = (route, fetch) => fetchProc.deleteData(route, fetch, appState);
+const putData = (route, data, fetch, okay = null, error = null) => fetchProc.putData(route, data, fetch, appState, okay, error);
+const deleteData = (route, fetch, okay = null, error = null) => fetchProc.deleteData(route, fetch, appState, okay, error);
 
 /* Function to GET all resources */
 export const fetchAll = () => {
@@ -171,7 +171,7 @@ export const exportOffers = (round, session) => {
 
 export const updateInstructor = (instructor) => {
     let fetch = true;
-    putData('/instructors', instructor, ()=>{
+    putData('/instructors/'+instructor.id, instructor, resp=>{
       getInstructors();
     },
     resp=>{
@@ -179,8 +179,8 @@ export const updateInstructor = (instructor) => {
       appState.hideInstructorModal();
     },
     resp=>{
-        appState.alert("<b>Error</b>: "+resp.message);
-        fetch = false;
+      appState.alert(resp.message);
+      fetch = false;
     });
 }
 
@@ -195,17 +195,9 @@ export const createInstructor = (instructor) => {
       appState.hideInstructorModal();
     },
     resp=>{
+      appState.alert(resp.message);
       fetch = false;
-      if(resp.id){
-        let choice = confirm("An instructor with the same utorid already exists. Do you want update the information for that instructor?");
-        if(choice){
-          appState.switchInstructorModalTab("update");
-        }
-      }
-      else{
-        appState.alert("<b>Error</b>: "+resp.message);
-      }
-    })
+    });
 }
 
 // get current user role and username

--- a/app/javascript/tapp/fetch.js
+++ b/app/javascript/tapp/fetch.js
@@ -170,9 +170,8 @@ export const exportOffers = (round, session) => {
 }
 
 export const updateInstructor = (instructor) => {
-    let fetch = true;
     putData('/instructors/'+instructor.id, instructor, resp=>{
-      if(fetch) getInstructors();
+      getInstructors();
     },
     resp=>{
       alert(resp.message);
@@ -180,14 +179,12 @@ export const updateInstructor = (instructor) => {
     },
     resp=>{
       appState.alert(resp.message);
-      fetch = false;
     });
 }
 
 export const deleteInstructor = (id) => {
-  let fetch = true;
   deleteData('/instructors/'+id, ()=>{
-    if(fetch) getInstructors();
+    getInstructors();
   },
   resp=>{
     alert(resp.message);
@@ -195,14 +192,12 @@ export const deleteInstructor = (id) => {
   },
   resp=>{
     appState.alert(resp.message);
-    fetch = false;
   });
 }
 
 export const createInstructor = (instructor) => {
-    let fetch = true;
     postData('/instructors', instructor, ()=>{
-      if(fetch) getInstructors();
+      getInstructors();
     },
     resp=>{
       alert(resp.message);
@@ -210,7 +205,6 @@ export const createInstructor = (instructor) => {
     },
     resp=>{
       appState.alert(resp.message);
-      fetch = false;
     });
 }
 

--- a/spec/controllers/instructors_controller_spec.rb
+++ b/spec/controllers/instructors_controller_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe InstructorsController, type: :controller do
 
   let(:instructor) do
     Instructor.create!(
+      utorid: "utorid",
       name: "instructor name",
       email: "email@example.com"
     )
@@ -33,5 +34,121 @@ RSpec.describe InstructorsController, type: :controller do
       end
     end
   end
+
+  describe "POST /instructors/" do
+    context "when expected" do
+      it "create new instructor" do
+        name = 'firstname lastname'
+        post :create, params: {utorid: 'poop', name: name, email: 'firstname.lastname@cs.toronto.edu'}
+        expect(response.status).to eq(200)
+        json = {message: "Instructor #{name} has been created.'"}.to_json
+        expect(response.body).to eq(json)
+      end
+    end
+
+    context "{utorid} already exists" do
+      it "throws status 404" do
+        post :create, params: {utorid: instructor[:utorid], name: 'firstname lastname', email: 'firstname.lastname@cs.toronto.edu'}
+        expect(response.status).to eq(404)
+        json = {message: "This instructor already exists."}.to_json
+        expect(response.body).to eq(json)
+      end
+    end
+
+    context "{name} is nil" do
+      it "throws status 404" do
+        post :create, params: {utorid: instructor[:id], email: 'firstname.lastname@cs.toronto.edu'}
+        expect(response.status).to eq(404)
+        json = {message: "Missing either name or email."}.to_json
+        expect(response.body).to eq(json)
+      end
+    end
+
+    context "{email} is nil" do
+      it "throws status 404" do
+        post :create, params: {utorid: instructor[:id], name: 'firstname lastname'}
+        expect(response.status).to eq(404)
+        json = {message: "Missing either name or email."}.to_json
+        expect(response.body).to eq(json)
+      end
+    end
+
+    context "{utorid} is nil" do
+      it "throws status 404" do
+        post :create, params: {name: 'firstname lastname', email: 'firstname.lastname@cs.toronto.edu'}
+        expect(response.status).to eq(404)
+        json = {message: "No utorid given."}.to_json
+        expect(response.body).to eq(json)
+      end
+    end
+  end
+
+  describe "PUT /instructors/{id}" do
+    context "when expected" do
+      it "update instructor" do
+        new_info = {
+          name: 'firstname lastname',
+          email: 'firstname.lastname@cs.toronto.edu'
+        }
+        patch :update, params: {id: instructor[:id], name: new_info[:name], email: new_info[:email]}
+        expect(response.status).to eq(200)
+        json = {message: "Instructor #{new_info[:name]}'s data has been updated.'"}.to_json
+        expect(response.body).to eq(json)
+        instructor.reload
+        expect(instructor[:name]).to eq(new_info[:name])
+        expect(instructor[:email]).to eq(new_info[:email])
+      end
+    end
+
+    context "{name} is nil" do
+      it "throws status 404" do
+        patch :update, params: {id: instructor[:id], email: 'firstname.lastname@cs.toronto.edu'}
+        expect(response.status).to eq(404)
+        json = {message: "Missing either name or email."}.to_json
+        expect(response.body).to eq(json)
+      end
+    end
+
+    context "{email} is nil" do
+      it "throws status 404" do
+        patch :update, params: {id: instructor[:id], name: 'firstname lastname'}
+        expect(response.status).to eq(404)
+        json = {message: "Missing either name or email."}.to_json
+        expect(response.body).to eq(json)
+      end
+    end
+
+    context "No instructor with {id}" do
+      it "throws status 404" do
+        id = 'poop'
+        patch :update, params: {id: id, name: 'firstname lastname', email: 'firstname.lastname@cs.toronto.edu'}
+        expect(response.status).to eq(404)
+        json = {message: "No instructor with id #{id} exists in the system."}.to_json
+        expect(response.body).to eq(json)
+      end
+    end
+  end
+
+  describe "DELETE /instructors/{id}" do
+    context "when expected" do
+      it "deletes the instructor" do
+        id = instructor[:id]
+        delete :destroy, params: {id: id}
+        expect(response.status).to eq(200)
+        json = {message: "Instructor #{id} has been deleted."}.to_json
+        expect{instructor.reload}.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when {id} is invalid" do
+      it "throws status 404" do
+        id = 'poop'
+        delete :destroy, params: {id: id}
+        expect(response.status).to eq(404)
+        json = {message: "No instructor with id #{id} exists in the system."}.to_json
+      end
+    end
+  end
+
 
 end


### PR DESCRIPTION
- fixes issue #92 
- created UI for adding/updating/deleting instructors
- in the Courses View
- the editor opens as a modal when the pencil icon next to `instructors` is clicked
- modal contains 2 tabs:
  - `Create Instructor`
   - can only create new instructor if given `utorid` not already in system
  - `Edit Instructor`
   - can update `name` and `email` of existing instructor
   - can also delete existing instructor
- both views will check for:
  - `name` to include both first and last name
  - `email` to have a valid format
- new routes:
  - `POST /instructors/`
  - `PUT /instructors/:id`
  - `DELETE /instructors/:id`
- finished rspecs for backend routes

![screenshot from 2018-04-26 14-44-31](https://user-images.githubusercontent.com/22383586/39325527-6e180018-4960-11e8-8169-2f6fcded1b9e.png)

![screenshot from 2018-04-26 14-42-32](https://user-images.githubusercontent.com/22383586/39325466-4118271e-4960-11e8-9f7d-17fc79bf519d.png)
![screenshot from 2018-04-26 14-43-24](https://user-images.githubusercontent.com/22383586/39325467-4329657c-4960-11e8-8580-90f0f6c39ba7.png)
