### PR TITLE
[WIP][Hotfix] Fix Summary Page Loading Issue

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 class SessionsController < ApplicationController
   protect_from_forgery with: :null_session
   include Authorizer
-  before_action :cp_access, except: [:update]
+  before_action :app_access, except: [:update]
   before_action :cp_admin, only: [:update]
 
   def index


### PR DESCRIPTION
- summary page doesn't not load because not all the fetches were completed
- cause: `applicants` routes has an internal server error
- fix: apparently the `applicants` routes stops giving issues once I switched to this branch
  - the cause of this `applicants` issue is unknown, but the summary page now loads