### PR TITLE
[Marina requested] fix downloadFile for Firefox

### DIFF
--- a/app/javascript/fetchProc.js
+++ b/app/javascript/fetchProc.js
@@ -416,7 +416,7 @@ export const downloadFile = (route, appState) =>{
       document.body.appendChild(a); //required in FF
       a.href = url;
       a.download = filename;
-      pom.target="_self" ; //required in FF
+      a.target="_self" ; //required in FF
       a.click();
       URL.revokeObjectURL(url);
       a.document.body.removeChild(a); //required in FF

--- a/app/javascript/fetchProc.js
+++ b/app/javascript/fetchProc.js
@@ -420,7 +420,7 @@ export const downloadFile = (route, appState) =>{
       document.body.appendChild(a); //required in FF
       a.click();
       URL.revokeObjectURL(url);
-      a.document.body.removeChild(a); //required in FF
+      document.body.removeChild(a); //required in FF
     }
     else{
       appState.alert(resp.message);

--- a/app/javascript/fetchProc.js
+++ b/app/javascript/fetchProc.js
@@ -411,16 +411,21 @@ export const downloadFile = (route, appState) =>{
   })
   .then(resp => {
     if(download){
-      let url = URL.createObjectURL(resp);
-      let a = document.createElement('a');
-      a.href = url;
-      a.download = filename;
-      a.target="_self" ; //required in FF
-      a.style.display = 'none';
-      document.body.appendChild(a); //required in FF
-      a.click();
-      URL.revokeObjectURL(url);
-      document.body.removeChild(a); //required in FF
+      if (window.navigator && window.navigator.msSaveOrOpenBlob) {
+        window.navigator.msSaveOrOpenBlob(blob, filename);
+      }
+      else{
+        let url = URL.createObjectURL(resp);
+        let a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.target="_self" ; //required in FF
+        a.style.display = 'none';
+        document.body.appendChild(a); //required in FF
+        a.click();
+        URL.revokeObjectURL(url);
+        document.body.removeChild(a); //required in FF
+      }
     }
     else{
       appState.alert(resp.message);

--- a/app/javascript/fetchProc.js
+++ b/app/javascript/fetchProc.js
@@ -413,10 +413,13 @@ export const downloadFile = (route, appState) =>{
     if(download){
       let url = URL.createObjectURL(resp);
       var a = document.createElement('a');
+      document.body.appendChild(a); //required in FF
       a.href = url;
       a.download = filename;
+      pom.target="_self" ; //required in FF
       a.click();
       URL.revokeObjectURL(url);
+      a.document.body.removeChild(a); //required in FF
     }
     else{
       appState.alert(resp.message);

--- a/app/javascript/fetchProc.js
+++ b/app/javascript/fetchProc.js
@@ -412,7 +412,7 @@ export const downloadFile = (route, appState) =>{
   .then(resp => {
     if(download){
       if (window.navigator && window.navigator.msSaveOrOpenBlob) {
-        window.navigator.msSaveOrOpenBlob(resp, filename);
+        window.navigator.msSaveOrOpenBlob(resp, filename); //special case for Edge & IE
       }
       else{
         let url = URL.createObjectURL(resp);

--- a/app/javascript/fetchProc.js
+++ b/app/javascript/fetchProc.js
@@ -412,7 +412,7 @@ export const downloadFile = (route, appState) =>{
   .then(resp => {
     if(download){
       if (window.navigator && window.navigator.msSaveOrOpenBlob) {
-        window.navigator.msSaveOrOpenBlob(blob, filename);
+        window.navigator.msSaveOrOpenBlob(resp, filename);
       }
       else{
         let url = URL.createObjectURL(resp);

--- a/app/javascript/fetchProc.js
+++ b/app/javascript/fetchProc.js
@@ -412,11 +412,12 @@ export const downloadFile = (route, appState) =>{
   .then(resp => {
     if(download){
       let url = URL.createObjectURL(resp);
-      var a = document.createElement('a');
-      document.body.appendChild(a); //required in FF
+      let a = document.createElement('a');
       a.href = url;
       a.download = filename;
       a.target="_self" ; //required in FF
+      a.style.display = 'none';
+      document.body.appendChild(a); //required in FF
       a.click();
       URL.revokeObjectURL(url);
       a.document.body.removeChild(a); //required in FF


### PR DESCRIPTION
- Issue: Firefox doesn't download blob sent from the server 
  - **Note:** Marina uses Firefox, so I told her to use Chrome for now
- Cause:
  - difference between Chrome and Firefox when handling the the download option in `<a>` tag
- Fix: Firefox requires that the `<a>` node be placed in the `document.body` and `target="_self"`
- Additionally, I added the fix for downloading in Edge & IE
  - apparently, those browsers follows a completely different approach when working with opening blobs