### PR TITLE
Update mimemagic: old version doesn't exist in repo anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /srv/app
 
 RUN apk --update --upgrade add curl-dev libcurl build-base openssh \
 	tzdata libxml2 libxml2-dev libxslt libxslt-dev postgresql-dev \
-	nodejs
+	nodejs shared-mime-info
 
 # Add Yarn to the mix
 # hideous hack by matz. methinks yarn lastest tarball changed.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,9 @@ GEM
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
-    mimemagic (0.3.2)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
@@ -231,6 +233,7 @@ DEPENDENCIES
   guard-rspec
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
+  mimemagic (~> 0.3.8)
   pg (~> 0.20)
   prawn (~> 2.2)
   puma (~> 3.7)


### PR DESCRIPTION
mimemagic 0.3.2 doesn't exist anymore. Update it to the next version that does exist and install any needed dependencies.

Reference: https://github.com/rails/rails/issues/41750 